### PR TITLE
Improve content negotiation API

### DIFF
--- a/examples/showcase/main.ml
+++ b/examples/showcase/main.ml
@@ -29,12 +29,15 @@ let user_handler id _req =
   Response.of_html ~status:`OK html
 
 let api_version_handler req =
-  Response.negotiate
-    req
-    [ (`Json, fun () -> {|{"message": "Hello from Tapak!", "version": "1.0"}|})
-    ; (`Html, fun () -> "<h1>Hello from Tapak!</h1><p>Version: 1.0</p>")
-    ; (`Text, fun () -> "Hello from Tapak!\nVersion: 1.0")
-    ]
+  Response.negotiate req (function
+    | `Json ->
+      Some
+        ( "application/json"
+        , {|{"message": "Hello from Tapak!", "version": "1.0"}|} )
+    | `Html ->
+      Some ("text/html", "<h1>Hello from Tapak!</h1><p>Version: 1.0</p>")
+    | `Text -> Some ("text/plain", "Hello from Tapak!\nVersion: 1.0")
+    | _ -> None)
 
 let files_handler path _req =
   let html =

--- a/src/header_parser.ml
+++ b/src/header_parser.ml
@@ -259,6 +259,8 @@ module Content_negotiation = struct
     | `Text -> Media_type.text
     | `Other s -> s
 
+  let default_accept_formats = [ `Json; `Html; `Xml; `Text ]
+
   let media_type_to_format = function
     | "application/json" -> `Json
     | "text/html" -> `Html

--- a/src/header_parser.mli
+++ b/src/header_parser.mli
@@ -137,6 +137,9 @@ module Content_negotiation : sig
     ]
   (** Common content format types *)
 
+  val default_accept_formats : format list
+  (** default list of accepted formats *)
+
   val format_to_media_type : format -> string
   (** Convert format to media type string.
 


### PR DESCRIPTION
Previously, the API require user to pass list of tuples (media_type, unit -> string). This was not very ergonomic, and there is no way to express 406 not acceptable response.

Now, the API instead require a function of format -> (string * string) option. When the function return None, the server will respond with 406 Not Acceptable. If it return Some (media_type, body), the server will respond normally with status code given to Response.negotiate function.