### PR TITLE
feature(router): prepare for OpenAPI generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Tapak
 
 > ⚠️ **Under Heavy Development**: This library is in active development and
-the API is not yet stable. Breaking changes may occur between releases.
-Not recommended for production use at this time.
+> the API is not yet stable. Breaking changes may occur between releases.
+> Not recommended for production use at this time.
 
 Tapak is a composable web framework for OCaml 5, built on EIO (effect-based I/O)
 and inspired by [Twitter's Finagle](https://twitter.github.io/finagle/) architecture.
@@ -15,16 +15,16 @@ and inspired by [Twitter's Finagle](https://twitter.github.io/finagle/) architec
 
 The OCaml ecosystem has several excellent web frameworks, each with different design philosophies:
 
-| Framework | Async Runtime | Routing | Philosophy | Status |
-|-----------|---------------|---------|------------|--------|
-| **[Dream](https://camlworks.github.io/dream/)** | Lwt | String patterns | Batteries-included, tidy | Stable* |
-| **[Opium](https://github.com/rgrinberg/opium)** | Lwt | String patterns | Sinatra-like micro-framework | Stable |
-| **[Eliom](https://ocsigen.org/eliom/)** | Lwt | Type-safe | Multi-tier, full-stack | Stable |
-| **[tiny_httpd](https://github.com/c-cube/tiny_httpd)** | Threads | GADT type-safe | Minimalist, thin dependencies | Stable* |
-| **Tapak** | **EIO (OCaml 5)** | **GADT type-safe** | Composable Service/Filter | **Experimental** |
+| Framework                                              | Async Runtime     | Routing            | Philosophy                    | Status           |
+| ------------------------------------------------------ | ----------------- | ------------------ | ----------------------------- | ---------------- |
+| **[Dream](https://camlworks.github.io/dream/)**        | Lwt               | String patterns    | Batteries-included, tidy      | Stable\*         |
+| **[Opium](https://github.com/rgrinberg/opium)**        | Lwt               | String patterns    | Sinatra-like micro-framework  | Stable           |
+| **[Eliom](https://ocsigen.org/eliom/)**                | Lwt               | Type-safe          | Multi-tier, full-stack        | Stable           |
+| **[tiny_httpd](https://github.com/c-cube/tiny_httpd)** | Threads           | GADT type-safe     | Minimalist, thin dependencies | Stable\*         |
+| **Tapak**                                              | **EIO (OCaml 5)** | **GADT type-safe** | Composable Service/Filter     | **Experimental** |
 
-- * Dream is stable but still evolving, it hasn't reached v1.0 yet.
-- * Tiny_httpd looks stable, but I haven't used it personally.
+- - Dream is stable but still evolving, it hasn't reached v1.0 yet.
+- - Tiny_httpd looks stable, but I haven't used it personally.
 
 ### Why Tapak?
 
@@ -133,9 +133,9 @@ let app env =
   let open Router in
   App.(
     routes
-      [ get (s "") @-> home_handler
-      ; get (s "users" / int64) @-> user_handler
-      ; get (s "api" / s "users" / int64 / str) @-> api_handler
+      [ get (s "") |> into home_handler
+      ; get (s "users" / int64) |> into user_handler
+      ; get (s "api" / s "users" / int64 / str) |> into api_handler
       ]
       ()
     <++> [ use ~name:"Logger" (module Request_logger)

--- a/examples/body-parsing/dune
+++ b/examples/body-parsing/dune
@@ -1,0 +1,7 @@
+(executable
+ (name main)
+ (package tapak)
+ (public_name tapak-body-parsing-examples)
+ (enabled_if
+  (= %{profile} dev))
+ (libraries tapak eio_main yojson logs logs.fmt fmt.tty logs.threaded))

--- a/examples/body-parsing/main.ml
+++ b/examples/body-parsing/main.ml
@@ -1,0 +1,276 @@
+open Tapak
+
+let create_user json_body _req =
+  let open Yojson.Safe.Util in
+  try
+    let name = json_body |> member "name" |> to_string in
+    let email = json_body |> member "email" |> to_string in
+    let _age = json_body |> member "age" |> to_int_option in
+
+    let response_json =
+      `Assoc
+        [ "status", `String "created"
+        ; "user", `Assoc [ "name", `String name; "email", `String email ]
+        ]
+    in
+
+    Response.of_json ~status:`Created response_json
+  with
+  | Type_error (msg, _) ->
+    let error = `Assoc [ "error", `String ("Invalid JSON: " ^ msg) ] in
+    Response.of_json ~status:`Bad_request error
+  | _ ->
+    let error = `Assoc [ "error", `String "Failed to parse JSON" ] in
+    Response.of_json ~status:`Bad_request error
+
+let update_user json_body id _req =
+  let open Yojson.Safe.Util in
+  try
+    let name = json_body |> member "name" |> to_string_option in
+    let email = json_body |> member "email" |> to_string_option in
+
+    let updates = [] in
+    let updates =
+      match name with
+      | Some n -> ("name", `String n) :: updates
+      | None -> updates
+    in
+    let updates =
+      match email with
+      | Some e -> ("email", `String e) :: updates
+      | None -> updates
+    in
+
+    let response_json =
+      `Assoc
+        [ "status", `String "updated"
+        ; "id", `Int (Int64.to_int id)
+        ; "updates", `Assoc updates
+        ]
+    in
+
+    Response.of_json ~status:`OK response_json
+  with
+  | _ ->
+    let error = `Assoc [ "error", `String "Failed to update user" ] in
+    Response.of_json ~status:`Bad_request error
+
+let login_form form_data _req =
+  match
+    ( Form.Urlencoded.get "username" form_data
+    , Form.Urlencoded.get "password" form_data )
+  with
+  | Some username, Some password ->
+    (* In a real app, you'd verify credentials here *)
+    if username <> "" && password <> ""
+    then
+      let response_json =
+        `Assoc
+          [ "status", `String "authenticated"
+          ; "username", `String username
+          ; "message", `String "Login successful"
+          ]
+      in
+      Response.of_json ~status:`OK response_json
+    else
+      let error =
+        `Assoc [ "error", `String "Username and password cannot be empty" ]
+      in
+      Response.of_json ~status:`Bad_request error
+  | None, _ ->
+    let error = `Assoc [ "error", `String "Missing username" ] in
+    Response.of_json ~status:`Bad_request error
+  | _, None ->
+    let error = `Assoc [ "error", `String "Missing password" ] in
+    Response.of_json ~status:`Bad_request error
+
+let contact_form form_data _req =
+  let name = Form.Urlencoded.get "name" form_data in
+  let email = Form.Urlencoded.get "email" form_data in
+  let message = Form.Urlencoded.get "message" form_data in
+  let subscribe = Form.Urlencoded.get "subscribe" form_data in
+
+  match name, email, message with
+  | Some n, Some e, Some m when n <> "" && e <> "" && m <> "" ->
+    let is_subscribed =
+      match subscribe with
+      | Some "on" | Some "true" | Some "1" -> true
+      | _ -> false
+    in
+
+    let response_json =
+      `Assoc
+        [ "status", `String "received"
+        ; ( "data"
+          , `Assoc
+              [ "name", `String n
+              ; "email", `String e
+              ; "message", `String m
+              ; "subscribed", `Bool is_subscribed
+              ] )
+        ]
+    in
+    Response.of_json ~status:`OK response_json
+  | _ ->
+    let error =
+      `Assoc
+        [ "error", `String "Missing required fields: name, email, message" ]
+    in
+    Response.of_json ~status:`Bad_request error
+
+let upload_file _multipart_data _req =
+  let response_json =
+    `Assoc
+      [ "status", `String "received"
+      ; "message", `String "Multipart upload endpoint"
+      ]
+  in
+  Response.of_json ~status:`OK response_json
+
+let list_users _req =
+  let users =
+    `List
+      [ `Assoc [ "id", `Int 1; "name", `String "Alice" ]
+      ; `Assoc [ "id", `Int 2; "name", `String "Bob" ]
+      ]
+  in
+  Response.of_json ~status:`OK users
+
+let html_page title body =
+  Printf.sprintf
+    {|<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>%s</title>
+  <style>
+    body { font-family: sans-serif; max-width: 800px; margin: 50px auto; padding: 20px; }
+    h1 { color: #333; }
+    .example { background: #f5f5f5; padding: 20px; margin: 20px 0; border-radius: 5px; }
+    code { background: #e0e0e0; padding: 2px 5px; border-radius: 3px; }
+    pre { background: #2d2d2d; color: #f8f8f2; padding: 15px; border-radius: 5px; overflow-x: auto; }
+    .endpoint { margin: 10px 0; }
+    .method { font-weight: bold; display: inline-block; width: 80px; }
+    .method.post { color: #49cc90; }
+    .method.put { color: #fca130; }
+    .method.get { color: #61affe; }
+  </style>
+</head>
+<body>
+  <h1>%s</h1>
+  %s
+</body>
+</html>|}
+    title
+    title
+    body
+
+let index_page _req =
+  let body =
+    {|
+  <p>This example demonstrates <strong>type-safe request body parsing</strong> with Tapak.</p>
+
+  <h2>Available Endpoints</h2>
+
+  <div class="example">
+    <h3>1. JSON Body (application/json)</h3>
+    <div class="endpoint">
+      <span class="method post">POST</span>
+      <code>/api/users</code> - Create a user
+    </div>
+    <pre>curl -X POST http://localhost:8080/api/users \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Alice", "email": "alice@example.com", "age": 30}'</pre>
+
+    <div class="endpoint">
+      <span class="method put">PUT</span>
+      <code>/api/users/:id</code> - Update a user
+    </div>
+    <pre>curl -X PUT http://localhost:8080/api/users/1 \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Alice Smith", "email": "alice.smith@example.com"}'</pre>
+
+    <div class="endpoint">
+      <span class="method get">GET</span>
+      <code>/api/users</code> - List users
+    </div>
+    <pre>curl http://localhost:8080/api/users</pre>
+  </div>
+
+  <div class="example">
+    <h3>2. URL-Encoded Form (application/x-www-form-urlencoded)</h3>
+    <div class="endpoint">
+      <span class="method post">POST</span>
+      <code>/login</code> - Login form
+    </div>
+    <pre>curl -X POST http://localhost:8080/login \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "username=alice&password=secret123"</pre>
+
+    <div class="endpoint">
+      <span class="method post">POST</span>
+      <code>/contact</code> - Contact form
+    </div>
+    <pre>curl -X POST http://localhost:8080/contact \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "name=Alice&email=alice@example.com&message=Hello!&subscribe=on"</pre>
+  </div>
+
+  <div class="example">
+    <h3>3. Multipart Form (multipart/form-data)</h3>
+    <div class="endpoint">
+      <span class="method post">POST</span>
+      <code>/upload</code> - File upload (pending implementation)
+    </div>
+    <pre>curl -X POST http://localhost:8080/upload \
+  -F "file=@document.pdf" \
+  -F "description=My document"</pre>
+  </div>
+
+  <h2>Type Safety Features</h2>
+  <ul>
+    <li>POST/PUT/PATCH can have request bodies</li>
+    <li>GET/HEAD <strong>cannot</strong> have request bodies (compile-time error)</li>
+    <li>Request body is automatically parsed based on Content-Type</li>
+    <li>Type-safe body access in handlers</li>
+  </ul>
+  |}
+  in
+  Response.of_html ~status:`OK (html_page "Body Parsing Example" body)
+
+let app env =
+  let open Router in
+  let open Middleware in
+  let clock = Eio.Stdenv.clock env in
+  let now () = Eio.Time.now clock in
+  App.(
+    routes
+      [ get (s "") |> into index_page
+      ; post (s "api" / s "users") |> req_body Json |> into create_user
+      ; put (s "api" / s "users" / p "userId" int64)
+        |> req_body Json
+        |> into update_user
+      ; get (s "api" / s "users") |> into list_users
+      ; post (s "login") |> req_body Urlencoded |> into login_form
+      ; post (s "contact") |> req_body Urlencoded |> into contact_form
+      ; post (s "upload") |> req_body Multipart |> into upload_file
+      ]
+      ()
+    <++> [ Middleware.use
+             ~name:"Request_logger"
+             (module Request_logger)
+             (Request_logger.args ~now ~trusted_proxies:[] ())
+         ])
+
+let () =
+  Logs_threaded.enable ();
+  Fmt_tty.setup_std_outputs ();
+  Logs.set_level (Some Logs.Info);
+  Logs.set_reporter (Logs_fmt.reporter ());
+  Eio_main.run @@ fun env ->
+  let address = `Tcp (Eio.Net.Ipaddr.V4.loopback, 8080) in
+  let config = Piaf.Server.Config.create address in
+  Logs.info (fun m -> m "Body Parsing Example");
+  Logs.info (fun m -> m "Listening on http://localhost:8080");
+  ignore (Server.run_with ~config ~env (app env))

--- a/examples/live-cursors/main.ml
+++ b/examples/live-cursors/main.ml
@@ -179,8 +179,8 @@ let () =
 
   let open Router in
   let all_routes =
-    [ (get (s "") @-> fun _req -> serve_static_file "index.html")
-    ; (get (s "static" / str) @-> fun file _req -> serve_static_file file)
+    [ get (s "") |> into (fun _req -> serve_static_file "index.html")
+    ; get (s "static" / str) |> into (fun file _req -> serve_static_file file)
     ; (* Mount WebSocket endpoint at /socket/websocket *)
       scope (s "socket") (Endpoint.routes ws_config)
     ]

--- a/examples/request-guard/main.ml
+++ b/examples/request-guard/main.ml
@@ -312,19 +312,24 @@ let setup_app () =
   App.(
     routes
       ~not_found
-      [ get (s "") @-> home_handler
+      [ get (s "") |> into home_handler
       ; (* Examples using request guard with >=> operator *)
         scope
           (s "manual")
-          [ get (api_key_guard >=> s "api-info") @-> api_info_handler
-          ; get (user_guard >=> s "profile") @-> profile_handler
-          ; get (admin_guard >=> s "admin") @-> admin_handler
-          ; post (authenticated_json_guard >=> s "posts")
-            @-> create_post_handler
-          ; put (user_guard >=> s "users" / int64) @-> update_user_handler
+          [ get (s "api-info") |> guard api_key_guard |> into api_info_handler
+          ; get (s "profile") |> guard user_guard |> into profile_handler
+          ; get (s "admin") |> guard admin_guard |> into admin_handler
+          ; post (s "posts")
+            |> guard authenticated_json_guard
+            |> into create_post_handler
+          ; put (s "users" / int64)
+            |> guard user_guard
+            |> into update_user_handler
           ; (* Multiple guards chained *)
-            get (admin_guard >=> (pagination_guard >=> s "users" / s "list"))
-            @-> user_list_handler
+            get (s "users" / s "list")
+            |> guard pagination_guard
+            |> guard admin_guard
+            |> into user_list_handler
           ]
       ]
       ()

--- a/examples/showcase/main.ml
+++ b/examples/showcase/main.ml
@@ -192,11 +192,11 @@ let setup_app env =
   App.(
     routes
       ~not_found
-      [ get (s "") @-> home_handler
-      ; get (s "users" / int64) @-> user_handler
+      [ get (s "") |> into home_handler
+      ; get (s "users" / int64) |> into user_handler
       ; scope
           (s "api")
-          [ get (s "version") @-> api_version_handler
+          [ get (s "version") |> into api_version_handler
           ; scope
               ~middlewares:
                 [ use
@@ -205,16 +205,16 @@ let setup_app env =
                     (Limit_request_size.args ~max_bytes)
                 ]
               (s "users")
-              [ get (s "") @-> api_users_handler
-              ; get int64 @-> api_detail_user_handler
-              ; post int64 @-> api_update_user_handler
+              [ get (s "") |> into api_users_handler
+              ; get int64 |> into api_detail_user_handler
+              ; post int64 |> into api_update_user_handler
               ]
           ]
-      ; get (s "files" / str) @-> files_handler
-      ; post (s "echo") @-> echo_handler
-      ; put (s "echo") @-> echo_handler
-      ; get (s "form") @-> form_get_handler
-      ; post (s "form") @-> form_post_handler
+      ; get (s "files" / str) |> into files_handler
+      ; post (s "echo") |> into echo_handler
+      ; put (s "echo") |> into echo_handler
+      ; get (s "form") |> into form_get_handler
+      ; post (s "form") |> into form_post_handler
       ]
       ()
     <++> [ use

--- a/examples/sse-chat/main.ml
+++ b/examples/sse-chat/main.ml
@@ -317,10 +317,10 @@ let () =
   let app =
     App.(
       routes
-        [ get (s "") @-> home_handler
-        ; get (s "chat") @-> chat_stream_handler ~clock room
-        ; ( post (s "chat" / int) @-> fun user_id req ->
-            post_message_handler room user_id req )
+        [ get (s "") |> into home_handler
+        ; get (s "chat") |> into (chat_stream_handler ~clock room)
+        ; post (s "chat" / int)
+          |> into (fun user_id req -> post_message_handler room user_id req)
         ]
         ())
   in

--- a/examples/static-files/main.ml
+++ b/examples/static-files/main.ml
@@ -49,8 +49,8 @@ let () =
   let app =
     App.(
       routes
-        [ get (s "api" / s "hello") @-> api_handler
-        ; get splat @-> Static.serve fs_backend ~config:static_config ()
+        [ get (s "api" / s "hello") |> into api_handler
+        ; get splat |> into (Static.serve fs_backend ~config:static_config ())
         ]
         ()
       <++> [ Middleware.(

--- a/pkg/channel/src/tapak_channel.ml
+++ b/pkg/channel/src/tapak_channel.ml
@@ -1742,7 +1742,7 @@ module Endpoint = struct
   let routes : config -> Tapak_kernel.Router.route list =
    fun config ->
     let open Tapak_kernel.Router in
-    [ get (s "websocket") @-> handler config ]
+    [ get (s "websocket") |> into (handler config) ]
 
   let disconnect : config -> Socket.id -> unit =
    fun config socket_id ->

--- a/pkg/channel/src/tapak_channel.mli
+++ b/pkg/channel/src/tapak_channel.mli
@@ -1,35 +1,8 @@
-(** Tapak Channel - Phoenix-compatible channels and presence
-    for OCaml
-
-    This module provides real-time communication primitives
-    inspired by Phoenix Channels, including:
-    - PubSub for message broadcasting
-    - Sockets for connection management
-    - Channels for topic-based communication
-    - Presence for distributed user tracking
-
-    The wire protocol is compatible with Phoenix's JavaScript
-    client. *)
-
-(** {1 Topic Patterns}
-
-    Type-safe topic patterns for compile-time verification of
-    topic structure. Similar to the router's path patterns but
-    for channel topics. *)
 module Topic : sig
   type t = string
   (** A topic string, e.g., "room:lobby" or "user:123" *)
 
   type (_, _) pattern
-  (** Type-safe topic pattern. The first type parameter
-      represents the function type needed to construct the
-      topic, and the second is the result type (always [t]).
-
-      Patterns are built by composing segments with the [/]
-      operator. Each segment consumes part of the topic string
-      separated by ":". *)
-
-  (** {2 Pattern Constructors} *)
 
   val s : string -> ('a, 'a) pattern
   (** Literal string segment. Matches exactly the given string.
@@ -84,9 +57,7 @@ end
 (** {1 PubSub}
 
     Publish-subscribe messaging system for broadcasting
-    messages across the application. Multiple backends can be
-    implemented (in-memory, PostgreSQL LISTEN/NOTIFY, Redis,
-    etc.). *)
+    messages across the application. *)
 module Pubsub : sig
   type message =
     { topic : Topic.t

--- a/pkg/kernel/src/dune
+++ b/pkg/kernel/src/dune
@@ -1,4 +1,4 @@
 (library
  (name tapak_kernel)
  (public_name tapak.kernel)
- (libraries piaf uri hmap eio logs))
+ (libraries piaf uri hmap eio logs yojson))

--- a/pkg/kernel/src/router.mli
+++ b/pkg/kernel/src/router.mli
@@ -1,313 +1,149 @@
-(** Type-safe routing with GADT-based combinators.
-
-    This module provides a type-safe routing API where route parameters are
-    automatically parsed and typed. Unlike string-based routing, parameter
-    types are enforced at compile time.
-
-    {[
-      open Route
-
-      (* Define a typed route *)
-      let user_route =
-        get (s "users" / int64 / s "posts" / str)
-        @-> fun user_id slug request ->
-          (* user_id: int64, slug: string, request: Request.t *)
-          Response.of_string
-            ~body:(Printf.sprintf "User %Ld post %s" user_id slug)
-            `OK
-    ]}
-*)
-
-(** {1 Exceptions} *)
-
 exception Not_found
-(** Raised when no route matches the request. *)
+exception Bad_request of string
 
-(** {1 Core Types} *)
+type _ content_type =
+  | Json : Yojson.Safe.t content_type
+  | Urlencoded : Form.Urlencoded.t content_type
+  | Multipart : Form.Multipart.t content_type
 
-type (_, _) path
-(** The type of a route pattern (internal GADT).
-    ['a] is the accumulated function type for extracted parameters.
-    ['b] is the final return type. *)
+type metadata =
+  { operation_id : string option
+  ; summary : string option
+  ; description : string option
+  ; tags : string list
+  ; body_description : string option
+  }
+
+type (_, _) path =
+  | Nil : ('a, 'a) path
+  | Literal : string * ('a, 'b) path -> ('a, 'b) path
+  | Capture :
+      { parse : string -> 'param option
+      ; format : 'param -> string
+      ; type_name : string
+      ; format_name : string option
+      ; rest : ('a, 'b) path
+      }
+      -> ('param -> 'a, 'b) path
+  | Enum :
+      { parse : string -> 'param option
+      ; format : 'param -> string
+      ; type_name : string
+      ; format_name : string option
+      ; values : 'param list
+      ; rest : ('a, 'b) path
+      }
+      -> ('param -> 'a, 'b) path
+  | Annotated :
+      { segment : ('a, 'b) path
+      ; name : string
+      ; description : string option
+      }
+      -> ('a, 'b) path
+  | Splat : ('a, 'b) path -> (string list -> 'a, 'b) path
+
+type (_, _) schema =
+  | Method : Piaf.Method.t * ('a, 'b) path -> ('a, 'b) schema
+  | Response_model :
+      { encoder : 'resp -> Response.t
+      ; rest : ('a, Request.t -> 'resp) schema
+      }
+      -> ('a, Request.t -> Response.t) schema
+  | Request_body :
+      { content_type : 'body content_type
+      ; rest : ('a, 'b) schema
+      }
+      -> ('body -> 'a, 'b) schema
+  | Guard :
+      { guard : 'g Request_guard.t
+      ; rest : ('a, 'b) schema
+      }
+      -> ('g -> 'a, 'b) schema
+  | Meta :
+      { meta : metadata
+      ; rest : ('a, 'b) schema
+      }
+      -> ('a, 'b) schema
 
 type route
-(** The type of a complete route with handler attached. *)
-
-(** {1 Combinators} *)
 
 val int : (int -> 'a, 'a) path
-(** [int] matches an integer path segment and extracts it as [int]. *)
-
 val int32 : (int32 -> 'a, 'a) path
-(** [int32] matches a 32-bit integer path segment. *)
-
 val int64 : (int64 -> 'a, 'a) path
-(** [int64] matches a 64-bit integer path segment. *)
-
 val str : (string -> 'a, 'a) path
-(** [str] matches any path segment and extracts it as [string]. *)
-
 val bool : (bool -> 'a, 'a) path
-(** [bool] matches "true" or "false" and extracts as [bool]. *)
-
 val splat : (string list -> 'a, 'a) path
-(** [splat] matches all remaining path segments and extracts them as [string list].
-    This is useful for catch-all routes, serving SPAs, or file browsers.
-    {[
-      (* Matches: /files/docs/readme.txt -> ["docs"; "readme.txt"] *)
-      get (s "files" / splat) @-> fun segments req -> ...
-    ]} *)
 
 val custom :
    parse:(string -> 'param option)
   -> format:('param -> string)
+  -> type_name:string
+  -> ?format_name:string
+  -> unit
   -> ('param -> 'a, 'a) path
-(** [custom ~parse ~format] creates a custom parameter extractor.
 
-    {b Custom Type Pattern (OCaml Value Restriction):}
-
-    Due to OCaml's value restriction, custom types must be defined as {b functions}
-    to be reusable for both routing and URL generation:
-
-    {[
-      (* Define as a function - note the () *)
-      let uuid () =
-        custom
-          ~parse:(fun s -> if is_valid_uuid s then Some s else None)
-          ~format:Fun.id
-
-      (* Manual usage - call it *)
-      get (s "articles" / uuid ()) @-> fun uuid_str req -> ...
-      let url = sprintf (s "articles" / uuid ()) "550e8400-..."
-
-      (* PPX usage - automatically calls it *)
-      let get_article ~id _req = ...[@@route GET, "/articles/<uuid:id>"]
-      (* ^^^ PPX generates: get (s "articles" / uuid ()) *)
-    ]}
-
-    {b Why functions?}
-    The expression [custom ~parse ~format] is non-expansive (calling a function
-    with function arguments), so OCaml assigns weak type variables that cannot
-    be reused polymorphically. Wrapping in a function [let uuid () = ...] makes
-    each call produce a fresh polymorphic value.
-
-    {b For PPX users:} The PPX automatically handles calling custom types as
-    functions, so you can use them naturally in route annotations.
-
-    {b For manual users:} Remember to call custom types: [uuid ()] not [uuid].
-*)
+val enum :
+   parse:(string -> 'param option)
+  -> format:('param -> string)
+  -> type_name:string
+  -> ?format_name:string
+  -> values:'param list
+  -> unit
+  -> ('param -> 'a, 'a) path
 
 val slug : (string -> 'a, 'a) path
-(** [slug] matches URL-friendly slugs (lowercase letters, numbers, hyphens).
-    This is useful for article URLs, product slugs, etc.
-    {[
-      (* Matches: /posts/my-awesome-post-123 *)
-      get (s "posts" / slug) @-> fun slug req -> ...
-    ]} *)
-
 val s : string -> ('a, 'a) path
-(** [s literal] matches a literal string segment. *)
-
 val ( / ) : ('a, 'c) path -> ('c, 'b) path -> ('a, 'b) path
-(** [( / )] chains two path segments together.
-    {[
-      s "users" / int64 / s "posts" / str
-    ]} *)
+val get : ('a, 'b) path -> ('a, 'b) schema
+val post : ('a, 'b) path -> ('a, 'b) schema
+val put : ('a, 'b) path -> ('a, 'b) schema
+val patch : ('a, 'b) path -> ('a, 'b) schema
+val delete : ('a, 'b) path -> ('a, 'b) schema
+val head : ('a, 'b) path -> ('a, 'b) schema
+val any : ('a, 'b) path -> ('a, 'b) schema
 
-(** {1 Handler Attachment} *)
+val req_body :
+   'body_type content_type
+  -> ('a, 'b) schema
+  -> ('body_type -> 'a, 'b) schema
 
-val ( @-> ) : ('a, Request.t -> Response.t) path -> 'a -> route
-(** [pattern @-> handler] attaches a handler to a route pattern.
-    The handler must accept all extracted parameters followed by [Request.t]. *)
+val guard : 'g Request_guard.t -> ('a, 'b) schema -> ('g -> 'a, 'b) schema
 
-(** {1 HTTP Methods} *)
+val response_model :
+   ('resp -> Response.t)
+  -> ('a, Request.t -> 'resp) schema
+  -> ('a, Request.t -> Response.t) schema
 
-val get : ('a, 'b) path -> ('a, 'b) path
-(** [get pattern] creates a GET route with the given pattern. *)
-
-val post : ('a, 'b) path -> ('a, 'b) path
-(** [post pattern] creates a POST route with the given pattern. *)
-
-val put : ('a, 'b) path -> ('a, 'b) path
-(** [put pattern] creates a PUT route with the given pattern. *)
-
-val patch : ('a, 'b) path -> ('a, 'b) path
-(** [patch pattern] creates a PATCH route with the given pattern. *)
-
-val delete : ('a, 'b) path -> ('a, 'b) path
-(** [delete pattern] creates a DELETE route with the given pattern. *)
-
-val head : ('a, 'b) path -> ('a, 'b) path
-(** [head pattern] creates a HEAD route with the given pattern. *)
-
-val any : ('a, 'b) path -> ('a, 'b) path
-(** [any pattern] creates a route that matches any HTTP method.
-    This is useful for catch-all endpoints like webhooks.
-    {[
-      (* Matches GET, POST, PUT, DELETE, etc. on /api/webhook *)
-      any (s "api" / s "webhook") @-> fun req -> ...
-    ]} *)
-
-(** {1 Request Guards} *)
-
-val ( >=> ) : 'g Request_guard.t -> ('a, 'b) path -> ('g -> 'a, 'b) path
-(** [guard >=> pattern] composes a request guard with a route pattern.
-    The guard extracts a value from the request and adds it as the first parameter
-    to the handler, before any path parameters.
-
-    This reads naturally left-to-right: "guard then path pattern".
-
-    Guards provide type-safe request validation and data extraction:
-    - If the guard succeeds, the extracted value is passed to the handler
-    - If the guard fails, a [Request_guard.Failed] exception is raised
-
-    {[
-      (* Define a guard *)
-      let user_guard : User.t Request_guard.t = fun req ->
-        match get_auth_token req with
-        | Some token -> verify_user token  (* Returns Ok user or Error err *)
-        | None -> Error Request_guard.Invalid_bearer_token
-
-      (* Use with router - reads "user guard then users path" *)
-      get (user_guard >=> s "users" / int64) @-> fun user id req ->
-        (* user : User.t, id : int64, req : Request.t *)
-        Response.of_string ~body:(Printf.sprintf "User %s viewing %Ld" user.name id) `OK
-
-      (* Multiple guards - compose with &&& *)
-      let authenticated_json = Request_guard.(user_guard &&& json_guard) in
-      post (authenticated_json >=> s "posts") @-> fun (user, ()) req -> ...
-
-      (* Chain multiple guards *)
-      get (user_guard >=> admin_guard >=> s "admin" / str) @->
-        fun user admin_role path req -> ...
-    ]}
-
-    See {!Request_guard} module for guard combinators and common guards. *)
-
-(** {1 Routing} *)
-
+val into : 'a -> ('a, Request.t -> Response.t) schema -> route
+val operation_id : string -> ('a, 'b) schema -> ('a, 'b) schema
+val summary : string -> ('a, 'b) schema -> ('a, 'b) schema
+val description : string -> ('a, 'b) schema -> ('a, 'b) schema
+val tags : string list -> ('a, 'b) schema -> ('a, 'b) schema
+val tag : string -> ('a, 'b) schema -> ('a, 'b) schema
+val p : string -> ('a, 'b) path -> ('a, 'b) path
+val ann : string * string -> ('a, 'b) path -> ('a, 'b) path
 val match' : route list -> Request.t -> Response.t option
-(** [match' routes request] attempts to match the request against the list of routes.
-    Returns [Some response] if a route matches, [None] otherwise. *)
-
 val router : route list -> Request.t -> Response.t
-(** [router routes] creates a request handler from a list of routes.
-    Raises [Not_found] if no route matches. *)
-
-(** {1 URL Generation} *)
-
 val sprintf : ('a, string) path -> 'a
-(** [sprintf pattern args...] generates a URL from a route pattern and arguments.
-
-    Works with any path pattern, extracting just the structure for URL generation:
-    {[
-      (* Define patterns *)
-      let user_path = s "users" / int64
-      let user_route_path = get (s "users" / int64)
-
-      (* Use for URL generation - works with both! *)
-      let url1 = sprintf user_path 42L  (* "/users/42" *)
-      let url2 = sprintf user_route_path 42L  (* "/users/42" *)
-    ]} *)
-
-(** {1 Scoping} *)
+val get_method : ('a, 'b) schema -> Piaf.Method.t
 
 val scope :
    ?middlewares:Middleware.t list
   -> ('a, 'a) path
   -> route list
   -> route
-(** [scope ?middlewares prefix routes] groups routes under a common prefix.
-    {[
-      scope ~middlewares:[auth; logging] (s "api" / s "v1") [
-        get (s "users") @-> users_handler;
-        get (s "posts") @-> posts_handler;
-      ]
-      (* Matches: /api/v1/users, /api/v1/posts *)
-    ]} *)
 
-(** {1 RESTful Resources} *)
-
-(** Module signature for defining RESTful resource handlers.
-
-    The Resource module allows you to specify the ID type and pattern for your
-    resource, making it flexible for different ID schemes (int64, UUID, slugs, etc.).
-
-    {[
-      (* Example: Resource with int64 IDs *)
-      module UserResource : Router.Resource = struct
-        type id = int64
-        let id_path () = Router.int64
-
-        let index _req = Response.of_string ~body:"User list" `OK
-        let new_ _req = Response.of_string ~body:"New user form" `OK
-        let create _req = Response.of_string ~body:"Create user" `OK
-        let get id _req =
-          Response.of_string ~body:(Printf.sprintf "User %Ld" id) `OK
-        let edit id _req =
-          Response.of_string ~body:(Printf.sprintf "Edit user %Ld" id) `OK
-        let update id _req =
-          Response.of_string ~body:(Printf.sprintf "Update user %Ld" id) `OK
-        let delete id _req =
-          Response.of_string ~body:(Printf.sprintf "Delete user %Ld" id) `OK
-      end
-
-      (* Example: Resource with UUID (string) IDs *)
-      module ArticleResource : Router.Resource = struct
-        type id = string
-        let id_path () = Router.custom
-          ~parse:(fun s -> if is_valid_uuid s then Some s else None)
-          ~format:Fun.id
-
-        let index _req = Response.of_string ~body:"Article list" `OK
-        let get uuid _req =
-          Response.of_string ~body:(Printf.sprintf "Article %s" uuid) `OK
-        (* ... other handlers *)
-      end
-
-      (* Example: Resource with slug IDs *)
-      module PostResource : Router.Resource = struct
-        type id = string
-        let id_path () = Router.slug
-
-        let index _req = Response.of_string ~body:"Post list" `OK
-        let get slug _req =
-          Response.of_string ~body:(Printf.sprintf "Post %s" slug) `OK
-        (* ... other handlers *)
-      end
-    ]} *)
 module type Resource = sig
   type id
-  (** The type of the resource identifier. *)
 
   val id_path : unit -> (id -> 'a, 'a) path
-  (** The path pattern for extracting the resource ID.
-      This allows you to specify custom validation and formatting for IDs.
-
-      {b Note:} Due to OCaml's value restriction, [id_path] must be a function
-      to allow reuse in both routing (within [resource]) and URL generation.
-      Define it as: [let id_path () = Router.int64] (note the [unit] parameter). *)
-
   val index : Handler.t
-  (** GET /resource - List all resources *)
-
   val new_ : Handler.t
-  (** GET /resource/new - Show form to create a new resource *)
-
   val create : Handler.t
-  (** POST /resource - Create a new resource *)
-
   val get : id -> Handler.t
-  (** GET /resource/:id - Show a specific resource *)
-
   val edit : id -> Handler.t
-  (** GET /resource/:id/edit - Show form to edit a resource *)
-
   val update : id -> Handler.t
-  (** PUT /resource/:id - Update a specific resource *)
-
   val delete : id -> Handler.t
-  (** DELETE /resource/:id - Delete a specific resource *)
 end
 
 val resource :
@@ -315,31 +151,3 @@ val resource :
   -> ('a, 'a) path
   -> (module Resource)
   -> route
-(** [resource ?middlewares prefix module] creates RESTful routes for a resource.
-
-    This generates 7 standard RESTful routes with proper HTTP methods:
-    - GET    /prefix          -> index
-    - GET    /prefix/new      -> new_
-    - POST   /prefix          -> create
-    - GET    /prefix/:id      -> get
-    - GET    /prefix/:id/edit -> edit
-    - PUT    /prefix/:id      -> update
-    - DELETE /prefix/:id      -> delete
-
-    {[
-      (* Using with int64 IDs *)
-      let routes = resource (s "users") (module UserResource)
-
-      (* Using with UUID IDs *)
-      let routes = resource (s "articles") (module ArticleResource)
-
-      (* With middleware *)
-      let routes = resource ~middlewares:[auth] (s "admin" / s "posts") (module PostResource)
-
-      (* URL generation for resource routes *)
-      let user_path = s "users" / UserResource.id_path ()
-      let url = sprintf user_path 42L  (* "/users/42" *)
-
-      let edit_path = s "users" / UserResource.id_path () / s "edit"
-      let edit_url = sprintf edit_path 42L  (* "/users/42/edit" *)
-    ]} *)

--- a/pkg/ppx/test/route-any.t/run.t
+++ b/pkg/ppx/test/route-any.t/run.t
@@ -4,7 +4,9 @@ ANY method route ppx functionality
     Tapak.Router.( / ) (Tapak.Router.s "api") (Tapak.Router.s "webhook")
   
   let resource_handler_path =
-    Tapak.Router.( / ) (Tapak.Router.s "resources") Tapak.Router.int64
+    Tapak.Router.( / )
+      (Tapak.Router.s "resources")
+      (Tapak.Router.p "id" Tapak.Router.int64)
   
   let webhook_handler request = Tapak.Response.of_string' "Webhook received"
   [@@route ANY, "/api/webhook"]
@@ -14,13 +16,13 @@ ANY method route ppx functionality
   [@@route ANY, "/resources/<int64:id>"]
   
   let webhook_handler_route =
-    Tapak.Router.( @-> )
-      (Tapak.Router.any
-         (Tapak.Router.( / ) (Tapak.Router.s "api") (Tapak.Router.s "webhook")))
-      webhook_handler
+    Tapak.Router.any
+      (Tapak.Router.( / ) (Tapak.Router.s "api") (Tapak.Router.s "webhook"))
+    |> Tapak.Router.into webhook_handler
   
   let resource_handler_route =
-    Tapak.Router.( @-> )
-      (Tapak.Router.any
-         (Tapak.Router.( / ) (Tapak.Router.s "resources") Tapak.Router.int64))
-      (fun id request -> resource_handler ~id request)
+    Tapak.Router.any
+      (Tapak.Router.( / )
+         (Tapak.Router.s "resources")
+         (Tapak.Router.p "id" Tapak.Router.int64))
+    |> Tapak.Router.into (fun id request -> resource_handler ~id request)

--- a/pkg/ppx/test/route-basic.t/run.t
+++ b/pkg/ppx/test/route-basic.t/run.t
@@ -1,14 +1,15 @@
 Basic route ppx functionality
   $ ../ppx.sh input.ml
   let user_handler_path =
-    Tapak.Router.( / ) (Tapak.Router.s "users") Tapak.Router.int
+    Tapak.Router.( / ) (Tapak.Router.s "users")
+      (Tapak.Router.p "id" Tapak.Router.int)
   
   let user_handler ~id request =
     Tapak.Response.of_string' (Format.sprintf "User ID: %d" id)
   [@@route GET, "/users/:id"]
   
   let user_handler_route =
-    Tapak.Router.( @-> )
-      (Tapak.Router.get
-         (Tapak.Router.( / ) (Tapak.Router.s "users") Tapak.Router.int))
-      (fun id request -> user_handler ~id request)
+    Tapak.Router.get
+      (Tapak.Router.( / ) (Tapak.Router.s "users")
+         (Tapak.Router.p "id" Tapak.Router.int))
+    |> Tapak.Router.into (fun id request -> user_handler ~id request)

--- a/pkg/ppx/test/route-circular.t/run.t
+++ b/pkg/ppx/test/route-circular.t/run.t
@@ -1,11 +1,14 @@
 Circular dependencies between routes
   $ ../ppx.sh input.ml
   let get_user_path =
-    Tapak.Router.( / ) (Tapak.Router.s "users") Tapak.Router.int64
+    Tapak.Router.( / ) (Tapak.Router.s "users")
+      (Tapak.Router.p "id" Tapak.Router.int64)
   
   let edit_user_path =
     Tapak.Router.( / ) (Tapak.Router.s "users")
-      (Tapak.Router.( / ) Tapak.Router.int64 (Tapak.Router.s "edit"))
+      (Tapak.Router.( / )
+         (Tapak.Router.p "id" Tapak.Router.int64)
+         (Tapak.Router.s "edit"))
   
   let get_user ~id request =
     let _edit_url = Tapak.Router.sprintf edit_user_path id in
@@ -18,14 +21,15 @@ Circular dependencies between routes
   [@@route GET, "/users/<int64:id>/edit"]
   
   let get_user_route =
-    Tapak.Router.( @-> )
-      (Tapak.Router.get
-         (Tapak.Router.( / ) (Tapak.Router.s "users") Tapak.Router.int64))
-      (fun id request -> get_user ~id request)
+    Tapak.Router.get
+      (Tapak.Router.( / ) (Tapak.Router.s "users")
+         (Tapak.Router.p "id" Tapak.Router.int64))
+    |> Tapak.Router.into (fun id request -> get_user ~id request)
   
   let edit_user_route =
-    Tapak.Router.( @-> )
-      (Tapak.Router.get
-         (Tapak.Router.( / ) (Tapak.Router.s "users")
-            (Tapak.Router.( / ) Tapak.Router.int64 (Tapak.Router.s "edit"))))
-      (fun id request -> edit_user ~id request)
+    Tapak.Router.get
+      (Tapak.Router.( / ) (Tapak.Router.s "users")
+         (Tapak.Router.( / )
+            (Tapak.Router.p "id" Tapak.Router.int64)
+            (Tapak.Router.s "edit")))
+    |> Tapak.Router.into (fun id request -> edit_user ~id request)

--- a/pkg/ppx/test/route-django.t/run.t
+++ b/pkg/ppx/test/route-django.t/run.t
@@ -1,13 +1,19 @@
 Django-style typed parameters
   $ ../ppx.sh input.ml
   let get_user_path =
-    Tapak.Router.( / ) (Tapak.Router.s "users") Tapak.Router.int64
+    Tapak.Router.( / ) (Tapak.Router.s "users")
+      (Tapak.Router.p "id" Tapak.Router.int64)
   
   let get_post_path =
-    Tapak.Router.( / ) (Tapak.Router.s "posts") Tapak.Router.slug
+    Tapak.Router.( / ) (Tapak.Router.s "posts")
+      (Tapak.Router.p "slug" Tapak.Router.slug)
   
-  let toggle_path = Tapak.Router.( / ) (Tapak.Router.s "toggle") Tapak.Router.bool
-  let get_article_path = Tapak.Router.( / ) (Tapak.Router.s "articles") (uuid ())
+  let toggle_path =
+    Tapak.Router.( / ) (Tapak.Router.s "toggle")
+      (Tapak.Router.p "enabled" Tapak.Router.bool)
+  
+  let get_article_path =
+    Tapak.Router.( / ) (Tapak.Router.s "articles") (Tapak.Router.p "id" (uuid ()))
   
   let get_user ~id request =
     Tapak.Response.of_string' (Format.sprintf "User ID: %Ld" id)
@@ -26,25 +32,26 @@ Django-style typed parameters
   [@@route GET, "/articles/<uuid:id>"]
   
   let get_user_route =
-    Tapak.Router.( @-> )
-      (Tapak.Router.get
-         (Tapak.Router.( / ) (Tapak.Router.s "users") Tapak.Router.int64))
-      (fun id request -> get_user ~id request)
+    Tapak.Router.get
+      (Tapak.Router.( / ) (Tapak.Router.s "users")
+         (Tapak.Router.p "id" Tapak.Router.int64))
+    |> Tapak.Router.into (fun id request -> get_user ~id request)
   
   let get_post_route =
-    Tapak.Router.( @-> )
-      (Tapak.Router.get
-         (Tapak.Router.( / ) (Tapak.Router.s "posts") Tapak.Router.slug))
-      (fun slug request -> get_post ~slug request)
+    Tapak.Router.get
+      (Tapak.Router.( / ) (Tapak.Router.s "posts")
+         (Tapak.Router.p "slug" Tapak.Router.slug))
+    |> Tapak.Router.into (fun slug request -> get_post ~slug request)
   
   let toggle_route =
-    Tapak.Router.( @-> )
-      (Tapak.Router.get
-         (Tapak.Router.( / ) (Tapak.Router.s "toggle") Tapak.Router.bool))
-      (fun enabled request -> toggle ~enabled request)
+    Tapak.Router.get
+      (Tapak.Router.( / ) (Tapak.Router.s "toggle")
+         (Tapak.Router.p "enabled" Tapak.Router.bool))
+    |> Tapak.Router.into (fun enabled request -> toggle ~enabled request)
   
   let get_article_route =
-    Tapak.Router.( @-> )
-      (Tapak.Router.get
-         (Tapak.Router.( / ) (Tapak.Router.s "articles") (uuid ())))
-      (fun id request -> get_article ~id request)
+    Tapak.Router.get
+      (Tapak.Router.( / )
+         (Tapak.Router.s "articles")
+         (Tapak.Router.p "id" (uuid ())))
+    |> Tapak.Router.into (fun id request -> get_article ~id request)

--- a/pkg/ppx/test/route-splat.t/run.t
+++ b/pkg/ppx/test/route-splat.t/run.t
@@ -8,7 +8,6 @@ Splat syntax is "**" and passed as ~splat argument
   [@@route GET, "/static/**"]
   
   let static_handler_route =
-    Tapak.Router.( @-> )
-      (Tapak.Router.get
-         (Tapak.Router.( / ) (Tapak.Router.s "static") Tapak.Router.splat))
-      (fun splat request -> static_handler ~splat request)
+    Tapak.Router.get
+      (Tapak.Router.( / ) (Tapak.Router.s "static") Tapak.Router.splat)
+    |> Tapak.Router.into (fun splat request -> static_handler ~splat request)


### PR DESCRIPTION
In preparation of OpenAPI schema generation, we need to refactor our router definition. The problem of previous implementation is we handle many things in path pattern. As a result, the (/) combinator can fail at runtime, and it hard to extract the pattern. Also we missing the parameter name data.

now we separate path pattern and schema. So we can easily extract the path patterns, the schema handle the high level logic like request body, method, etc.

This PR is big since the router is the heart of the framework.