### PR TITLE
refactor: simplify middleware API

### DIFF
--- a/examples/live-cursors/main.ml
+++ b/examples/live-cursors/main.ml
@@ -190,7 +190,6 @@ let () =
       routes all_routes ()
       <++> [ Middleware.(
                use
-                 ~name:"Request_logger"
                  (module Request_logger)
                  (Request_logger.args ~now ~trusted_proxies:[] ()))
            ])

--- a/examples/ppx/main.ml
+++ b/examples/ppx/main.ml
@@ -70,7 +70,6 @@ let () =
         ]
         ()
       <++> [ use
-               ~name:"Request_logger"
                (module Request_logger)
                (Request_logger.args ~now ~trusted_proxies ())
            ])

--- a/examples/reason/main.re
+++ b/examples/reason/main.re
@@ -151,7 +151,6 @@ let () = {
         )
         <++> [
           use(
-            ~name="Request_logger",
             (module Request_logger),
             Request_logger.args(~now, ~trusted_proxies, ()),
           ),

--- a/examples/request-guard/main.ml
+++ b/examples/request-guard/main.ml
@@ -333,10 +333,7 @@ let setup_app () =
           ]
       ]
       ()
-    <++> [ Middleware.create
-             ~name:"Guard_error_handler"
-             ~filter:guard_error_middleware
-         ])
+    <++> [ guard_error_middleware ])
 
 let setup_log level =
   Fmt_tty.setup_std_outputs ();

--- a/examples/showcase/main.ml
+++ b/examples/showcase/main.ml
@@ -200,7 +200,6 @@ let setup_app env =
           ; scope
               ~middlewares:
                 [ use
-                    ~name:"Limit_request_size"
                     (module Limit_request_size)
                     (Limit_request_size.args ~max_bytes)
                 ]
@@ -218,10 +217,9 @@ let setup_app env =
       ]
       ()
     <++> [ use
-             ~name:"Request_logger"
              (module Request_logger)
              (Request_logger.args ~now ~trusted_proxies ())
-         ; use ~name:"Decompression" (module Decompression) decoder
+         ; use (module Decompression) decoder
          ])
 
 let setup_log ?(threaded = false) ?style_renderer level =

--- a/examples/static-files/main.ml
+++ b/examples/static-files/main.ml
@@ -55,7 +55,6 @@ let () =
         ()
       <++> [ Middleware.(
                use
-                 ~name:"Request_logger"
                  (module Request_logger)
                  (Request_logger.args ~now ~trusted_proxies ()))
            ; Middleware.head

--- a/pkg/kernel/src/app.ml
+++ b/pkg/kernel/src/app.ml
@@ -8,7 +8,7 @@ let ( <++> ) t ms = { t with middlewares = t.middlewares @ ms }
 let create ?(middlewares = []) ~handler () = { middlewares; handler }
 
 let call t request =
-  let service = Middleware.apply_all t.middlewares t.handler in
+  let service = Filter.apply_all t.middlewares t.handler in
   service request
 
 let use = Middleware.use

--- a/pkg/kernel/src/app.mli
+++ b/pkg/kernel/src/app.mli
@@ -13,11 +13,5 @@ val create :
   -> t
 
 val call : t -> Request.t -> Response.t
-
-val use :
-   name:string
-  -> (module Middleware.Intf with type t = 'a)
-  -> 'a
-  -> Middleware.t
-
+val use : (module Middleware.Intf with type t = 'a) -> 'a -> Middleware.t
 val to_piaf : t -> Piaf.Request_info.t Piaf.Server.Handler.t

--- a/pkg/kernel/src/middleware.ml
+++ b/pkg/kernel/src/middleware.ml
@@ -1,16 +1,4 @@
-type t =
-  { filter : (Request.t, Response.t) Filter.simple
-  ; name : string
-  }
-
-let create ~filter ~name = { filter; name }
-let apply { filter; _ } handler = filter handler
-
-let apply_all mws handler =
-  let filters = List.map (fun mw -> mw.filter) mws in
-  Filter.apply_all filters handler
-
-let pp fmt { name; _ } = Format.fprintf fmt "Middleware(%s)" name
+type t = (Request.t, Response.t) Filter.simple
 
 module type Intf = sig
   type t
@@ -18,5 +6,4 @@ module type Intf = sig
   val call : t -> (Request.t, Response.t) Filter.simple
 end
 
-let use (type a) ~name (module M : Intf with type t = a) (args : a) =
-  { name; filter = M.call args }
+let use (type a) (module M : Intf with type t = a) (args : a) = M.call args

--- a/pkg/kernel/src/middleware.mli
+++ b/pkg/kernel/src/middleware.mli
@@ -1,21 +1,4 @@
-(** Middleware is a name, simple filter, that can be applied to a service. *)
-
-type t =
-  { filter : (Request.t, Response.t) Filter.simple
-  ; name : string
-  }
-
-val create : filter:(Request.t, Response.t) Filter.simple -> name:string -> t
-
-val apply :
-   t
-  -> (Request.t, Response.t) Service.t
-  -> (Request.t, Response.t) Service.t
-
-val apply_all :
-   t list
-  -> (Request.t, Response.t) Service.t
-  -> (Request.t, Response.t) Service.t
+type t = (Request.t, Response.t) Filter.simple
 
 module type Intf = sig
   type t
@@ -23,5 +6,4 @@ module type Intf = sig
   val call : t -> (Request.t, Response.t) Filter.simple
 end
 
-val use : name:string -> (module Intf with type t = 'a) -> 'a -> t
-val pp : Format.formatter -> t -> unit
+val use : (module Intf with type t = 'a) -> 'a -> t

--- a/pkg/kernel/src/router.ml
+++ b/pkg/kernel/src/router.ml
@@ -455,7 +455,7 @@ let rec match_route ?(middlewares = []) route segments request =
   | Route route ->
     (match match_schema route.schema segments request route.handler with
     | Some handler ->
-      let service = Middleware.apply_all middlewares handler in
+      let service = Filter.apply_all middlewares handler in
       Some (service request)
     | None -> None)
   | Scope scope ->

--- a/pkg/kernel/test/test_router.ml
+++ b/pkg/kernel/test/test_router.ml
@@ -204,7 +204,7 @@ let test_scope_with_middlewares () =
         resp
   end
   in
-  let test_middleware = Middleware.use ~name:"test" (module M) () in
+  let test_middleware = Middleware.use (module M) () in
   let route =
     scope
       ~middlewares:[ test_middleware ]

--- a/src/middleware/middleware_head.ml
+++ b/src/middleware/middleware_head.ml
@@ -8,13 +8,10 @@
     server MUST NOT send a message body. The server SHOULD send the same
     headers as it would for a GET request. *)
 
-let m =
-  let filter next request =
-    if Request.meth request = `HEAD
-    then
-      let get_request = Request.with_ ~meth:`GET request in
-      let response = next get_request in
-      Response.with_ ~body:Body.empty response
-    else next request
-  in
-  Tapak_kernel.Middleware.create ~name:"middleware_head" ~filter
+let m next request =
+  if Request.meth request = `HEAD
+  then
+    let get_request = Request.with_ ~meth:`GET request in
+    let response = next get_request in
+    Response.with_ ~body:Body.empty response
+  else next request

--- a/test/test_middleware_compression.ml
+++ b/test/test_middleware_compression.ml
@@ -69,12 +69,10 @@ let test_no_accept_encoding () =
     }
   in
 
-  let compression_middleware =
-    Middleware.(use ~name:"compression" (module Compression) args)
-  in
+  let compression_middleware = Middleware.(use (module Compression) args) in
 
   let handler _req = original_response in
-  let response = Middleware.apply compression_middleware handler request in
+  let response = compression_middleware handler request in
 
   Alcotest.(check (option string))
     "Content-Encoding is gzip"
@@ -97,12 +95,10 @@ let test_compression_with_gzip () =
     }
   in
 
-  let compression_middleware =
-    Middleware.(use ~name:"compression" (module Compression) args)
-  in
+  let compression_middleware = Middleware.(use (module Compression) args) in
 
   let handler _req = original_response in
-  let response = Middleware.apply compression_middleware handler request in
+  let response = compression_middleware handler request in
 
   Alcotest.(check (option string))
     "Content-Encoding is gzip"
@@ -132,12 +128,10 @@ let test_vary_header_merge () =
     }
   in
 
-  let compression_middleware =
-    Middleware.(use ~name:"compression" (module Compression) args)
-  in
+  let compression_middleware = Middleware.(use (module Compression) args) in
 
   let handler _req = original_response in
-  let response = Middleware.apply compression_middleware handler request in
+  let response = compression_middleware handler request in
 
   Alcotest.(check (option string))
     "Vary header merged"
@@ -157,12 +151,10 @@ let test_vary_header_no_duplicate () =
     }
   in
 
-  let compression_middleware =
-    Middleware.(use ~name:"compression" (module Compression) args)
-  in
+  let compression_middleware = Middleware.(use (module Compression) args) in
 
   let handler _req = original_response in
-  let response = Middleware.apply compression_middleware handler request in
+  let response = compression_middleware handler request in
 
   Alcotest.(check (option string))
     "Vary header not duplicated"
@@ -179,12 +171,10 @@ let test_identity_encoding () =
     ; encoder = make_mock_encoder `Gzip
     }
   in
-  let compression_middleware =
-    Middleware.(use ~name:"compression" (module Compression) args)
-  in
+  let compression_middleware = Middleware.(use (module Compression) args) in
 
   let handler _req = original_response in
-  let response = Middleware.apply compression_middleware handler request in
+  let response = compression_middleware handler request in
 
   Alcotest.(check (option string))
     "no Content-Encoding for identity"
@@ -203,11 +193,11 @@ let test_predicate_blocks_compression () =
   in
 
   let compression_middleware =
-    Middleware.use ~name:"compression" (module Middleware.Compression) args
+    Middleware.use (module Middleware.Compression) args
   in
 
   let handler _req = original_response in
-  let response = Middleware.apply compression_middleware handler request in
+  let response = compression_middleware handler request in
 
   Alcotest.(check (option string))
     "predicate blocks compression"
@@ -226,11 +216,11 @@ let test_no_encoder_available () =
   in
 
   let compression_middleware =
-    Middleware.use ~name:"compression" (module Middleware.Compression) args
+    Middleware.use (module Middleware.Compression) args
   in
 
   let handler _req = original_response in
-  let response = Middleware.apply compression_middleware handler request in
+  let response = compression_middleware handler request in
 
   Alcotest.(check (option string))
     "no compression without encoder"
@@ -248,11 +238,11 @@ let test_compression_failure () =
     }
   in
   let compression_middleware =
-    Middleware.use ~name:"compression" (module Middleware.Compression) args
+    Middleware.use (module Middleware.Compression) args
   in
 
   let handler _req = original_response in
-  let response = Middleware.apply compression_middleware handler request in
+  let response = compression_middleware handler request in
 
   Alcotest.(check (option string))
     "keeps Content-Length on failure"
@@ -275,12 +265,10 @@ let test_encoding_preference () =
     }
   in
 
-  let compression_middleware =
-    Middleware.(use ~name:"compression" (module Compression) args)
-  in
+  let compression_middleware = Middleware.(use (module Compression) args) in
 
   let handler _req = original_response in
-  let response = Middleware.apply compression_middleware handler request in
+  let response = compression_middleware handler request in
 
   Alcotest.(check (option string))
     "prefers gzip"
@@ -299,12 +287,10 @@ let test_replace_content_encoding () =
     ; encoder = make_mock_encoder `Gzip
     }
   in
-  let compression_middleware =
-    Middleware.(use ~name:"compression" (module Compression) args)
-  in
+  let compression_middleware = Middleware.(use (module Compression) args) in
 
   let handler _req = original_response in
-  let response = Middleware.apply compression_middleware handler request in
+  let response = compression_middleware handler request in
 
   Alcotest.(check (option string))
     "Content-Encoding replaced"


### PR DESCRIPTION
now middleware is just a function handler to handler, and not carry name field anymore.