### PR TITLE
feature: implement OpenAPI schema generation

### DIFF
--- a/examples/openapi/dune
+++ b/examples/openapi/dune
@@ -1,0 +1,7 @@
+(executable
+ (name main)
+ (package tapak)
+ (public_name tapak-openapi-examples)
+ (enabled_if
+  (= %{profile} dev))
+ (libraries tapak eio_main yojson logs logs.fmt fmt.tty logs.threaded))

--- a/examples/openapi/main.ml
+++ b/examples/openapi/main.ml
@@ -1,0 +1,162 @@
+open Tapak
+
+type user =
+  { id : int
+  ; name : string
+  ; email : string
+  }
+
+let user_to_json { id; name; email } =
+  `Assoc [ "id", `Int id; "name", `String name; "email", `String email ]
+
+let list_users _req =
+  Response.of_json
+    ~status:`OK
+    (`List
+        (List.map
+           user_to_json
+           [ { id = 1; name = "Alice"; email = "alice@example.com" } ]))
+
+let get_user id _req =
+  Response.of_json
+    ~status:`OK
+    (user_to_json { id; name = "Alice"; email = "alice@example.com" })
+
+let create_user (name, email) _req =
+  Response.of_json ~status:`Created (user_to_json { id = 2; name; email })
+
+let update_user (name, email) id _req =
+  Response.of_json ~status:`OK (user_to_json { id; name; email })
+
+let delete_user id _req =
+  Response.of_string ~body:(Format.sprintf "User %d deleted" id) `No_content
+
+let user_schema =
+  let open Schema.Syntax in
+  let+ name =
+    Schema.(
+      str
+        ~constraint_:
+          (Constraint.all_of
+             [ Constraint.min_length 1; Constraint.max_length 125 ])
+        "name")
+  and+ email = Schema.(str ~constraint_:(Constraint.format `Email) "email") in
+  name, email
+
+let v1_api_routes =
+  let open Router in
+  [ get (s "users")
+    |> summary "List all users"
+    |> operation_id "listUsers"
+    |> tags [ "Users" ]
+    |> into list_users
+  ; get (s "users" / p "userId" int)
+    |> summary "Get a user by ID"
+    |> operation_id "getUser"
+    |> tags [ "Users" ]
+    |> into get_user
+  ; post (s "users")
+    |> body Schema.Json user_schema
+    |> summary "Create a new user"
+    |> operation_id "createUser"
+    |> tags [ "Users" ]
+    |> into create_user
+  ; put (s "users" / p "userId" int)
+    |> body Schema.Json user_schema
+    |> summary "Update a user"
+    |> operation_id "updateUser"
+    |> tags [ "Users" ]
+    |> into update_user
+  ; delete (s "users" / p "userId" int)
+    |> summary "Delete a user"
+    |> operation_id "deleteUser"
+    |> tags [ "Users" ]
+    |> into delete_user
+  ]
+
+let api_v1_routes =
+  let open Router in
+  [ scope (s "v1") v1_api_routes ]
+
+let openapi_schema ?base_path routes _ =
+  Response.of_json
+    ~status:`OK
+    (Openapi.generate
+       ~title:"User API"
+       ~version:"1.0.0"
+       ~description:"A simple user management API"
+       ~base_path:(Option.value ~default:"" base_path)
+       routes)
+
+let swagger_ui_handler _ =
+  let html =
+    {|<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>User API - Swagger UI</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css" />
+  <style>
+    .swagger-ui .topbar {
+      display: none;
+    }
+  </style>
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-standalone-preset.js"></script>
+  <script>
+    window.onload = function() {
+      window.ui = SwaggerUIBundle({
+        url: '/openapi.json',
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        plugins: [
+          SwaggerUIBundle.plugins.DownloadUrl
+        ],
+        layout: "StandaloneLayout"
+      });
+    };
+  </script>
+</body>
+</html>|}
+  in
+  Response.of_html ~status:`OK html
+
+let app env =
+  let open Router in
+  let open Middleware in
+  let clock = Eio.Stdenv.clock env in
+  let now () = Eio.Time.now clock in
+
+  App.(
+    routes
+      [ scope (s "api") api_v1_routes
+      ; get (s "docs") |> into swagger_ui_handler
+      ; get (s "openapi.json")
+        |> into (openapi_schema ~base_path:"/api" api_v1_routes)
+      ]
+      ()
+    <++> [ head
+         ; use
+             (module Request_logger)
+             (Request_logger.args ~now ~trusted_proxies:[] ())
+         ])
+
+let () =
+  Logs_threaded.enable ();
+  Fmt_tty.setup_std_outputs ();
+  Logs.set_level (Some Logs.Info);
+  Logs.set_reporter (Logs_fmt.reporter ());
+  Eio_main.run @@ fun env ->
+  let address = `Tcp (Eio.Net.Ipaddr.V4.loopback, 8080) in
+  let config = Piaf.Server.Config.create address in
+  Logs.info (fun m -> m "Open Api Example");
+  Logs.info (fun m -> m "Listening on http://localhost:8080");
+  ignore (Server.run_with ~config ~env (app env))

--- a/pkg/kernel/src/router.ml
+++ b/pkg/kernel/src/router.ml
@@ -36,6 +36,7 @@ type metadata =
   ; description : string option
   ; tags : string list
   ; body_description : string option
+  ; include_in_schema : bool
   }
 
 type (_, _) schema =
@@ -76,7 +77,7 @@ let int : (int -> 'a, 'a) path =
     { parse = parse_int
     ; format = string_of_int
     ; type_name = "integer"
-    ; format_name = Some "int32"
+    ; format_name = None
     ; rest = Nil
     }
 
@@ -236,6 +237,7 @@ let empty_metadata =
   ; description = None
   ; tags = []
   ; body_description = None
+  ; include_in_schema = true
   }
 
 let operation_id : type a b. string -> (a, b) schema -> (a, b) schema =
@@ -254,6 +256,10 @@ let tags : type a b. string list -> (a, b) schema -> (a, b) schema =
 
 let tag : type a b. string -> (a, b) schema -> (a, b) schema =
  fun t rest -> Meta { meta = { empty_metadata with tags = [ t ] }; rest }
+
+let include_in_schema : type a b. bool -> (a, b) schema -> (a, b) schema =
+ fun value rest ->
+  Meta { meta = { empty_metadata with include_in_schema = value }; rest }
 
 let p : type a b. string -> (a, b) path -> (a, b) path =
  fun name segment -> Annotated { segment; name; description = None }

--- a/pkg/kernel/src/router.mli
+++ b/pkg/kernel/src/router.mli
@@ -8,6 +8,7 @@ type metadata =
   ; description : string option
   ; tags : string list
   ; body_description : string option
+  ; include_in_schema : bool
   }
 
 type (_, _) path =
@@ -62,7 +63,18 @@ type (_, _) schema =
       }
       -> ('a, 'b) schema
 
-type route
+type route =
+  | Route :
+      { schema : ('a, Request.t -> Response.t) schema
+      ; handler : 'a
+      }
+      -> route
+  | Scope :
+      { prefix : ('a, 'a) path
+      ; routes : route list
+      ; middlewares : Middleware.t list
+      }
+      -> route
 
 val int : (int -> 'a, 'a) path
 val int32 : (int32 -> 'a, 'a) path
@@ -118,6 +130,7 @@ val summary : string -> ('a, 'b) schema -> ('a, 'b) schema
 val description : string -> ('a, 'b) schema -> ('a, 'b) schema
 val tags : string list -> ('a, 'b) schema -> ('a, 'b) schema
 val tag : string -> ('a, 'b) schema -> ('a, 'b) schema
+val include_in_schema : bool -> ('a, 'b) schema -> ('a, 'b) schema
 val p : string -> ('a, 'b) path -> ('a, 'b) path
 val ann : string * string -> ('a, 'b) path -> ('a, 'b) path
 val match' : route list -> Request.t -> Response.t option

--- a/pkg/kernel/src/schema.mli
+++ b/pkg/kernel/src/schema.mli
@@ -61,7 +61,7 @@ module Constraint : sig
   val any_of : 'a t list -> 'a t
   val all_of : 'a t list -> 'a t
   val one_of : 'a t list -> 'a t
-  val not_ : 'a t -> 'a t
+  val not : 'a t -> 'a t
 
   val eval : 'a t -> 'a -> ('a, string list) result
   (** Evaluate a single constraint against a value. Returns Ok value if the constraint
@@ -75,6 +75,10 @@ module Constraint : sig
   val apply_constraint : 'a t option -> 'a -> ('a, string list) result
   (** Apply an optional constraint to a value. Returns Ok value if the constraint is None
       or if the constraint is satisfied. Returns Error if the constraint fails. *)
+
+  val to_json_schema : 'a t -> (string * Yojson.Safe.t) list
+  (** Convert a constraint to JSON Schema properties. Returns a list of key-value pairs
+      that can be merged into a JSON Schema object. *)
 end
 
 type _ input =

--- a/src/dune
+++ b/src/dune
@@ -8,6 +8,7 @@
   eio
   ipaddr
   yojson
+  str
   logs
   mirage-crypto
   mirage-crypto-rng

--- a/src/openapi.ml
+++ b/src/openapi.ml
@@ -1,0 +1,561 @@
+open Tapak_kernel
+
+type parameter =
+  { name : string
+  ; in_ : [ `Path | `Query | `Header ]
+  ; description : string option
+  ; required : bool
+  ; schema : Yojson.Safe.t
+  }
+
+type request_body =
+  { description : string option
+  ; required : bool
+  ; content : (string * Yojson.Safe.t) list
+  }
+
+type operation =
+  { operation_id : string option
+  ; summary : string option
+  ; description : string option
+  ; tags : string list
+  ; parameters : parameter list
+  ; request_body : request_body option
+  ; responses : Yojson.Safe.t
+  }
+
+type path_item =
+  { get : operation option
+  ; post : operation option
+  ; put : operation option
+  ; patch : operation option
+  ; delete : operation option
+  ; head : operation option
+  }
+
+let rec path_to_string : type a b. (a, b) Router.path -> string * parameter list
+  =
+ fun path ->
+  match path with
+  | Nil -> "", []
+  | Literal (lit, rest) ->
+    let rest_path, params = path_to_string rest in
+    (if lit = "" then rest_path else "/" ^ lit ^ rest_path), params
+  | Capture { type_name; format_name; rest; _ } ->
+    let rest_path, params = path_to_string rest in
+    let param_name = "param" ^ string_of_int (List.length params) in
+    let schema =
+      match format_name with
+      | Some format ->
+        `Assoc [ "type", `String type_name; "format", `String format ]
+      | None -> `Assoc [ "type", `String type_name ]
+    in
+    let param =
+      { name = param_name
+      ; in_ = `Path
+      ; description = None
+      ; required = true
+      ; schema
+      }
+    in
+    Format.sprintf "/{%s}%s" param_name rest_path, param :: params
+  | Enum { type_name; format_name; values; rest; format; _ } ->
+    let rest_path, params = path_to_string rest in
+    let param_name = "param" ^ string_of_int (List.length params) in
+    let enum_values = List.map (fun v -> `String (format v)) values in
+    let schema =
+      match format_name with
+      | Some format ->
+        `Assoc
+          [ "type", `String type_name
+          ; "format", `String format
+          ; "enum", `List enum_values
+          ]
+      | None -> `Assoc [ "type", `String type_name; "enum", `List enum_values ]
+    in
+    let param =
+      { name = param_name
+      ; in_ = `Path
+      ; description = None
+      ; required = true
+      ; schema
+      }
+    in
+    Format.sprintf "/{%s}%s" param_name rest_path, param :: params
+  | Annotated { segment; name; description } ->
+    let seg_path, params = path_to_string segment in
+    (match params with
+    | param :: rest ->
+      let updated_param = { param with name; description } in
+      let old_pattern = "{" ^ param.name ^ "}" in
+      let new_pattern = "{" ^ name ^ "}" in
+      let regexp = Str.regexp_string old_pattern in
+      let updated_path = Str.global_replace regexp new_pattern seg_path in
+      updated_path, updated_param :: rest
+    | [] -> seg_path, params)
+  | Splat rest ->
+    let rest_path, params = path_to_string rest in
+    let param_name = "splat" in
+    let param =
+      { name = param_name
+      ; in_ = `Path
+      ; description = Some "Catch-all path segments"
+      ; required = true
+      ; schema = `Assoc [ "type", `String "string" ]
+      }
+    in
+    Format.sprintf "/{%s}%s" param_name rest_path, param :: params
+
+let rec extract_metadata : type a b. (a, b) Router.schema -> Router.metadata =
+ fun schema ->
+  match schema with
+  | Method _ ->
+    { operation_id = None
+    ; summary = None
+    ; description = None
+    ; tags = []
+    ; body_description = None
+    ; include_in_schema = true
+    }
+  | Body { rest; _ } -> extract_metadata rest
+  | Guard { rest; _ } -> extract_metadata rest
+  | Response_model { rest; _ } -> extract_metadata rest
+  | Meta { meta; rest } ->
+    let base_meta = extract_metadata rest in
+    { operation_id =
+        (match meta.operation_id with
+        | Some _ as id -> id
+        | None -> base_meta.operation_id)
+    ; summary =
+        (match meta.summary with Some _ as s -> s | None -> base_meta.summary)
+    ; description =
+        (match meta.description with
+        | Some _ as d -> d
+        | None -> base_meta.description)
+    ; tags = meta.tags @ base_meta.tags
+    ; body_description =
+        (match meta.body_description with
+        | Some _ as bd -> bd
+        | None -> base_meta.body_description)
+    ; include_in_schema = meta.include_in_schema && base_meta.include_in_schema
+    }
+
+let rec field_to_openapi_schema : type a. a Schema.field -> Yojson.Safe.t =
+ fun field ->
+  match field with
+  | Str { default; constraint_ } ->
+    let base = [ "type", `String "string" ] in
+    let with_default =
+      match default with
+      | Some d -> ("default", `String d) :: base
+      | None -> base
+    in
+    let with_constraints =
+      match constraint_ with
+      | Some c -> Schema.Constraint.to_json_schema c @ with_default
+      | None -> with_default
+    in
+    `Assoc with_constraints
+  | Int { default; constraint_ } ->
+    let base = [ "type", `String "integer"; "format", `String "int32" ] in
+    let with_default =
+      match default with Some d -> ("default", `Int d) :: base | None -> base
+    in
+    let with_constraints =
+      match constraint_ with
+      | Some c -> Schema.Constraint.to_json_schema c @ with_default
+      | None -> with_default
+    in
+    `Assoc with_constraints
+  | Int32 { default; constraint_ } ->
+    let base = [ "type", `String "integer"; "format", `String "int32" ] in
+    let with_default =
+      match default with
+      | Some d -> ("default", `Int (Int32.to_int d)) :: base
+      | None -> base
+    in
+    let with_constraints =
+      match constraint_ with
+      | Some c -> Schema.Constraint.to_json_schema c @ with_default
+      | None -> with_default
+    in
+    `Assoc with_constraints
+  | Int64 { default; constraint_ } ->
+    let base = [ "type", `String "integer"; "format", `String "int64" ] in
+    let with_default =
+      match default with
+      | Some d -> ("default", `Int (Int64.to_int d)) :: base
+      | None -> base
+    in
+    let with_constraints =
+      match constraint_ with
+      | Some c -> Schema.Constraint.to_json_schema c @ with_default
+      | None -> with_default
+    in
+    `Assoc with_constraints
+  | Bool { default } ->
+    let base = [ "type", `String "boolean" ] in
+    let with_default =
+      match default with Some d -> ("default", `Bool d) :: base | None -> base
+    in
+    `Assoc with_default
+  | Float { default; constraint_ } ->
+    let base = [ "type", `String "number"; "format", `String "float" ] in
+    let with_default =
+      match default with
+      | Some d -> ("default", `Float d) :: base
+      | None -> base
+    in
+    let with_constraints =
+      match constraint_ with
+      | Some c -> Schema.Constraint.to_json_schema c @ with_default
+      | None -> with_default
+    in
+    `Assoc with_constraints
+  | Option inner ->
+    let inner_schema = field_to_openapi_schema inner in
+    (match inner_schema with
+    | `Assoc fields -> `Assoc (("nullable", `Bool true) :: fields)
+    | _ -> inner_schema)
+  | List { item; default; constraint_ } ->
+    let item_schema = field_to_openapi_schema item in
+    let base = [ "type", `String "array"; "items", item_schema ] in
+    let with_default =
+      match default with
+      | Some [] -> ("default", `List []) :: base
+      | Some _ -> base
+      | None -> base
+    in
+    let with_constraints =
+      match constraint_ with
+      | Some c -> Schema.Constraint.to_json_schema c @ with_default
+      | None -> with_default
+    in
+    `Assoc with_constraints
+  | File -> `Assoc [ "type", `String "string"; "format", `String "binary" ]
+  | Choice { choices; default; _ } ->
+    let enum_values = List.map (fun (key, _) -> `String key) choices in
+    let base = [ "type", `String "string"; "enum", `List enum_values ] in
+    let with_default = match default with Some _ -> base | None -> base in
+    `Assoc with_default
+  | Object schema -> schema_to_openapi_schema schema
+
+and schema_to_openapi_schema : type a. a Schema.t -> Yojson.Safe.t =
+ fun schema ->
+  match schema with
+  | Pure _ -> `Assoc [ "type", `String "object" ]
+  | Field { field; name } ->
+    let field_schema = field_to_openapi_schema field in
+    `Assoc
+      [ "type", `String "object"; "properties", `Assoc [ name, field_schema ] ]
+  | App (left, right) ->
+    let left_schema = schema_to_openapi_schema left in
+    let right_schema = schema_to_openapi_schema right in
+    (match left_schema, right_schema with
+    | `Assoc left_fields, `Assoc right_fields ->
+      let left_props =
+        List.assoc_opt "properties" left_fields
+        |> Option.value ~default:(`Assoc [])
+      in
+      let right_props =
+        List.assoc_opt "properties" right_fields
+        |> Option.value ~default:(`Assoc [])
+      in
+      (match left_props, right_props with
+      | `Assoc lp, `Assoc rp ->
+        `Assoc [ "type", `String "object"; "properties", `Assoc (lp @ rp) ]
+      | _ -> left_schema)
+    | _ -> left_schema)
+  | Map { tree; _ } -> schema_to_openapi_schema tree
+
+let rec extract_request_body : type a b.
+  (a, b) Router.schema -> request_body option
+  =
+ fun schema ->
+  match schema with
+  | Method _ -> None
+  | Body { input_type; schema; _ } ->
+    let content_type =
+      match input_type with
+      | Json -> "application/json"
+      | Urlencoded -> "application/x-www-form-urlencoded"
+      | Multipart -> "multipart/form-data"
+    in
+    let body_schema = schema_to_openapi_schema schema in
+    Some
+      { description = None
+      ; required = true
+      ; content = [ content_type, body_schema ]
+      }
+  | Guard { rest; _ } -> extract_request_body rest
+  | Response_model { rest; _ } -> extract_request_body rest
+  | Meta { rest; _ } -> extract_request_body rest
+
+let schema_to_operation : type a b. (a, b) Router.schema -> operation =
+ fun schema ->
+  let metadata = extract_metadata schema in
+  let rec get_path : type a b. (a, b) Router.schema -> string * parameter list =
+   fun s ->
+    match s with
+    | Method (_, path) -> path_to_string path
+    | Body { rest; _ } -> get_path rest
+    | Guard { rest; _ } -> get_path rest
+    | Response_model { rest; _ } -> get_path rest
+    | Meta { rest; _ } -> get_path rest
+  in
+  let _, parameters = get_path schema in
+  let request_body =
+    match extract_request_body schema with
+    | Some body -> Some { body with description = metadata.body_description }
+    | None -> None
+  in
+  { operation_id = metadata.operation_id
+  ; summary = metadata.summary
+  ; description = metadata.description
+  ; tags = metadata.tags
+  ; parameters
+  ; request_body
+  ; responses =
+      `Assoc
+        [ ( "200"
+          , `Assoc
+              [ "description", `String "Successful response"
+              ; ( "content"
+                , `Assoc
+                    [ ( "application/json"
+                      , `Assoc [ "schema", `Assoc [ "type", `String "object" ] ]
+                      )
+                    ] )
+              ] )
+        ]
+  }
+
+let parameter_to_json param =
+  let in_str =
+    match param.in_ with
+    | `Path -> "path"
+    | `Query -> "query"
+    | `Header -> "header"
+  in
+  let base =
+    [ "name", `String param.name
+    ; "in", `String in_str
+    ; "required", `Bool param.required
+    ; "schema", param.schema
+    ]
+  in
+  let with_description =
+    match param.description with
+    | Some desc -> ("description", `String desc) :: base
+    | None -> base
+  in
+  `Assoc with_description
+
+let request_body_to_json body =
+  let content =
+    `Assoc
+      (List.map
+         (fun (ct, schema) -> ct, `Assoc [ "schema", schema ])
+         body.content)
+  in
+  let base = [ "required", `Bool body.required; "content", content ] in
+  let with_description =
+    match body.description with
+    | Some desc -> ("description", `String desc) :: base
+    | None -> base
+  in
+  `Assoc with_description
+
+let operation_to_json op =
+  let base = [ "responses", op.responses ] in
+  let with_operation_id =
+    match op.operation_id with
+    | Some id -> ("operationId", `String id) :: base
+    | None -> base
+  in
+  let with_summary =
+    match op.summary with
+    | Some s -> ("summary", `String s) :: with_operation_id
+    | None -> with_operation_id
+  in
+  let with_description =
+    match op.description with
+    | Some d -> ("description", `String d) :: with_summary
+    | None -> with_summary
+  in
+  let with_tags =
+    if op.tags = []
+    then with_description
+    else
+      ("tags", `List (List.map (fun t -> `String t) op.tags))
+      :: with_description
+  in
+  let with_parameters =
+    if op.parameters = []
+    then with_tags
+    else
+      ("parameters", `List (List.map parameter_to_json op.parameters))
+      :: with_tags
+  in
+  let with_request_body =
+    match op.request_body with
+    | Some body -> ("requestBody", request_body_to_json body) :: with_parameters
+    | None -> with_parameters
+  in
+  `Assoc with_request_body
+
+let path_item_to_json (item : path_item) : Yojson.Safe.t option =
+  let fields = [] in
+  let with_get =
+    match item.get with
+    | Some op -> ("get", operation_to_json op) :: fields
+    | None -> fields
+  in
+  let with_post =
+    match item.post with
+    | Some op -> ("post", operation_to_json op) :: with_get
+    | None -> with_get
+  in
+  let with_put =
+    match item.put with
+    | Some op -> ("put", operation_to_json op) :: with_post
+    | None -> with_post
+  in
+  let with_patch =
+    match item.patch with
+    | Some op -> ("patch", operation_to_json op) :: with_put
+    | None -> with_put
+  in
+  let with_delete =
+    match item.delete with
+    | Some op -> ("delete", operation_to_json op) :: with_patch
+    | None -> with_patch
+  in
+  let with_head =
+    match item.head with
+    | Some op -> ("head", operation_to_json op) :: with_delete
+    | None -> with_delete
+  in
+  if with_head = [] then None else Some (`Assoc with_head)
+
+let rec extract_paths ?(prefix = "") (routes : Router.route list) :
+  (string * path_item) list
+  =
+  let merge_operations path_map path (method_key : Piaf.Method.t) operation =
+    let existing =
+      List.assoc_opt path path_map
+      |> Option.value
+           ~default:
+             { get = None
+             ; post = None
+             ; put = None
+             ; patch = None
+             ; delete = None
+             ; head = None
+             }
+    in
+    let updated =
+      match method_key with
+      | `GET -> { existing with get = Some operation }
+      | `POST -> { existing with post = Some operation }
+      | `PUT -> { existing with put = Some operation }
+      | `DELETE -> { existing with delete = Some operation }
+      | `HEAD -> { existing with head = Some operation }
+      | `Other "PATCH" -> { existing with patch = Some operation }
+      | _ -> existing
+    in
+    (path, updated) :: List.filter (fun (p, _) -> p <> path) path_map
+  in
+  let process_route acc = function
+    | Router.Route { schema; _ } ->
+      let metadata = extract_metadata schema in
+      if not metadata.include_in_schema
+      then acc
+      else
+        let operation = schema_to_operation schema in
+        let rec get_path_and_method : type a b.
+          (a, b) Router.schema -> string * Piaf.Method.t
+          =
+         fun s ->
+          match s with
+          | Method (meth, path) ->
+            let path_str, _ = path_to_string path in
+            prefix ^ path_str, meth
+          | Body { rest; _ } -> get_path_and_method rest
+          | Guard { rest; _ } -> get_path_and_method rest
+          | Response_model { rest; _ } -> get_path_and_method rest
+          | Meta { rest; _ } -> get_path_and_method rest
+        in
+        let path, method_ = get_path_and_method schema in
+        merge_operations acc path method_ operation
+    | Router.Scope { prefix = scope_prefix; routes; _ } ->
+      let scope_path_str, _ = path_to_string scope_prefix in
+      let new_prefix = prefix ^ scope_path_str in
+      let nested_paths = extract_paths ~prefix:new_prefix routes in
+      List.fold_left
+        (fun acc (path, item) ->
+           match List.assoc_opt path acc with
+           | None -> (path, item) :: acc
+           | Some existing ->
+             let merged =
+               { get =
+                   (match item.get with
+                   | Some _ as g -> g
+                   | None -> existing.get)
+               ; post =
+                   (match item.post with
+                   | Some _ as p -> p
+                   | None -> existing.post)
+               ; put =
+                   (match item.put with
+                   | Some _ as p -> p
+                   | None -> existing.put)
+               ; patch =
+                   (match item.patch with
+                   | Some _ as p -> p
+                   | None -> existing.patch)
+               ; delete =
+                   (match item.delete with
+                   | Some _ as d -> d
+                   | None -> existing.delete)
+               ; head =
+                   (match item.head with
+                   | Some _ as h -> h
+                   | None -> existing.head)
+               }
+             in
+             (path, merged) :: List.filter (fun (p, _) -> p <> path) acc)
+        acc
+        nested_paths
+  in
+  List.fold_left process_route [] routes
+
+let generate
+      ?(title = "API Documentation")
+      ?(version = "1.0.0")
+      ?(description = "")
+      ?(base_path = "")
+      (routes : Router.route list) : Yojson.Safe.t
+  =
+  let paths = extract_paths ~prefix:base_path routes in
+  let paths_json =
+    List.filter_map
+      (fun (path, item) ->
+         match path_item_to_json item with
+         | Some json -> Some (path, json)
+         | None -> None)
+      paths
+  in
+  let info =
+    `Assoc
+      [ "title", `String title
+      ; "version", `String version
+      ; "description", `String description
+      ]
+  in
+  `Assoc
+    [ "openapi", `String "3.0.0"; "info", info; "paths", `Assoc paths_json ]
+
+let to_string ?title ?version ?description ?base_path routes =
+  generate ?title ?version ?description ?base_path routes
+  |> Yojson.Safe.pretty_to_string

--- a/src/openapi.mli
+++ b/src/openapi.mli
@@ -1,0 +1,15 @@
+val generate :
+   ?title:string
+  -> ?version:string
+  -> ?description:string
+  -> ?base_path:string
+  -> Router.route list
+  -> Yojson.Safe.t
+
+val to_string :
+   ?title:string
+  -> ?version:string
+  -> ?description:string
+  -> ?base_path:string
+  -> Router.route list
+  -> string

--- a/src/tapak.ml
+++ b/src/tapak.ml
@@ -17,3 +17,4 @@ module Csrf = Csrf
 module Versions = Versions
 module Static = Static
 module Sse = Sse
+module Openapi = Openapi

--- a/src/tapak.mli
+++ b/src/tapak.mli
@@ -17,3 +17,4 @@ module Csrf = Csrf
 module Versions = Versions
 module Static = Static
 module Sse = Sse
+module Openapi = Openapi

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,4 @@
 (test
  (name test)
  (package tapak)
- (libraries tapak alcotest eio_main))
+ (libraries tapak yojson alcotest eio_main))

--- a/test/test.ml
+++ b/test/test.ml
@@ -6,4 +6,5 @@ let () =
        ; Test_middleware_compression.tests
        ; Test_static.tests
        ; Test_sse.tests
+       ; Test_openapi.tests
        ])

--- a/test/test_openapi.ml
+++ b/test/test_openapi.ml
@@ -1,0 +1,216 @@
+open Tapak
+
+let simple_handler _req = Response.of_string ~body:"OK" `OK
+
+let test_basic_generation () =
+  let open Router in
+  let routes =
+    [ get (s "users")
+      |> summary "List users"
+      |> operation_id "listUsers"
+      |> into simple_handler
+    ; post (s "users")
+      |> summary "Create user"
+      |> operation_id "createUser"
+      |> into simple_handler
+    ]
+  in
+  let spec = Openapi.generate ~title:"Test API" ~version:"1.0.0" routes in
+  match spec with
+  | `Assoc fields ->
+    let openapi_version = List.assoc "openapi" fields in
+    Alcotest.(check string)
+      "openapi version"
+      "3.0.0"
+      (match openapi_version with `String v -> v | _ -> "")
+  | _ -> Alcotest.fail "Expected object"
+
+let test_path_parameters () =
+  let open Router in
+  let routes =
+    [ get (s "users" / int)
+      |> summary "Get user by ID"
+      |> operation_id "getUser"
+      |> into (fun _id _req -> Response.of_string ~body:"User" `OK)
+    ]
+  in
+  let spec = Openapi.generate routes in
+  match spec with
+  | `Assoc fields ->
+    (match List.assoc "paths" fields with
+    | `Assoc paths ->
+      Alcotest.(check bool)
+        "has /users/{param0} path"
+        true
+        (List.mem_assoc "/users/{param0}" paths)
+    | _ -> Alcotest.fail "Expected paths object")
+  | _ -> Alcotest.fail "Expected object"
+
+let test_annotated_parameters () =
+  let open Router in
+  let routes =
+    [ get (s "users" / p "userId" int)
+      |> summary "Get user by ID"
+      |> into (fun _id _req -> Response.of_string ~body:"User" `OK)
+    ]
+  in
+  let spec = Openapi.generate routes in
+  match spec with
+  | `Assoc fields ->
+    (match List.assoc "paths" fields with
+    | `Assoc paths ->
+      Alcotest.(check bool)
+        "has /users/{userId} path"
+        true
+        (List.mem_assoc "/users/{userId}" paths)
+    | _ -> Alcotest.fail "Expected paths object")
+  | _ -> Alcotest.fail "Expected object"
+
+let test_request_body () =
+  let open Router in
+  let open Schema.Syntax in
+  let user_schema =
+    let+ name = Schema.str "name"
+    and+ age = Schema.int "age" in
+    name, age
+  in
+  let routes =
+    [ post (s "users")
+      |> body Schema.Json user_schema
+      |> summary "Create user"
+      |> into (fun (_name, _age) _req ->
+        Response.of_string ~body:"Created" `Created)
+    ]
+  in
+  let spec = Openapi.generate routes in
+  try
+    let operation =
+      List.fold_left
+        (fun acc name -> Yojson.Safe.Util.member name acc)
+        spec
+        [ "paths"; "/users"; "post" ]
+    in
+    match operation with
+    | `Assoc op_fields ->
+      Alcotest.(check bool)
+        "has requestBody"
+        true
+        (List.mem_assoc "requestBody" op_fields)
+    | _ -> Alcotest.fail "Expected post operation object"
+  with
+  | Yojson.Safe.Util.Type_error _ ->
+    Alcotest.fail "Expected post operation object"
+
+let test_scoped_routes () =
+  let open Router in
+  let routes =
+    [ scope
+        (s "api" / s "v1")
+        [ get (s "users") |> into simple_handler
+        ; get (s "posts") |> into simple_handler
+        ]
+    ]
+  in
+  let spec = Openapi.generate routes in
+  match spec with
+  | `Assoc fields ->
+    (match List.assoc "paths" fields with
+    | `Assoc paths ->
+      Alcotest.(check bool)
+        "has /api/v1/users path"
+        true
+        (List.mem_assoc "/api/v1/users" paths);
+      Alcotest.(check bool)
+        "has /api/v1/posts path"
+        true
+        (List.mem_assoc "/api/v1/posts" paths)
+    | _ -> Alcotest.fail "Expected paths object")
+  | _ -> Alcotest.fail "Expected object"
+
+let test_base_path () =
+  let open Router in
+  let routes = [ get (s "users") |> into simple_handler ] in
+  let spec = Openapi.generate ~base_path:"/api" routes in
+  match spec with
+  | `Assoc fields ->
+    (match List.assoc "paths" fields with
+    | `Assoc paths ->
+      Alcotest.(check bool)
+        "has /api/users path"
+        true
+        (List.mem_assoc "/api/users" paths)
+    | _ -> Alcotest.fail "Expected paths object")
+  | _ -> Alcotest.fail "Expected object"
+
+let test_tags () =
+  let open Router in
+  let routes =
+    [ get (s "users") |> tags [ "Users"; "Management" ] |> into simple_handler ]
+  in
+  let spec = Openapi.generate routes in
+  try
+    let operation =
+      List.fold_left
+        (fun acc name -> Yojson.Safe.Util.member name acc)
+        spec
+        [ "paths"; "/users"; "get" ]
+    in
+    match operation with
+    | `Assoc op_fields ->
+      (match List.assoc "tags" op_fields with
+      | `List tags -> Alcotest.(check int) "has 2 tags" 2 (List.length tags)
+      | _ -> Alcotest.fail "Expected tags array")
+    | _ -> Alcotest.fail "Expected get operation object"
+  with
+  | Yojson.Safe.Util.Type_error _ ->
+    Alcotest.fail "Expected get operation object"
+
+let test_include_in_schema () =
+  let open Router in
+  let routes =
+    [ get (s "users")
+      |> summary "List users"
+      |> operation_id "listUsers"
+      |> into simple_handler
+    ; get (s "internal" / s "health")
+      |> summary "Internal health check"
+      |> include_in_schema false
+      |> into simple_handler
+    ; post (s "users")
+      |> summary "Create user"
+      |> operation_id "createUser"
+      |> into simple_handler
+    ]
+  in
+  let spec = Openapi.generate routes in
+  match spec with
+  | `Assoc fields ->
+    (match List.assoc "paths" fields with
+    | `Assoc paths ->
+      Alcotest.(check bool)
+        "has /users path"
+        true
+        (List.mem_assoc "/users" paths);
+      Alcotest.(check bool)
+        "does not have /internal/health path"
+        false
+        (List.mem_assoc "/internal/health" paths);
+      Alcotest.(check int) "has 1 path" 1 (List.length paths)
+    | _ -> Alcotest.fail "Expected paths object")
+  | _ -> Alcotest.fail "Expected object"
+
+let tests =
+  [ ( "OpenAPI"
+    , [ Alcotest.test_case "Basic generation" `Quick test_basic_generation
+      ; Alcotest.test_case "Path parameters" `Quick test_path_parameters
+      ; Alcotest.test_case
+          "Annotated parameters"
+          `Quick
+          test_annotated_parameters
+      ; Alcotest.test_case "Request body" `Quick test_request_body
+      ; Alcotest.test_case "Scoped routes" `Quick test_scoped_routes
+      ; Alcotest.test_case "Base path" `Quick test_base_path
+      ; Alcotest.test_case "Tags" `Quick test_tags
+      ; Alcotest.test_case "Include in schema" `Quick test_include_in_schema
+      ] )
+  ]


### PR DESCRIPTION
This commit introduces functionality to generate OpenAPI schemas based on the defined routes. It's not complete yet, mainly we missing query and header parameters, but it provides a solid foundation for documenting APIs using OpenAPI.