### PR TITLE
fix: decode path segment in router

### DIFF
--- a/pkg/kernel/src/router.ml
+++ b/pkg/kernel/src/router.ml
@@ -319,6 +319,7 @@ module Path_cursor = struct
       then next { t with pos = end_pos + 1 }
       else
         let segment = String.sub t.path t.pos (end_pos - t.pos) in
+        let segment = Uri.pct_decode segment in
         let next_pos = if end_pos < t.len then end_pos + 1 else end_pos in
         Some (segment, { t with pos = next_pos })
 


### PR DESCRIPTION
Web frameworks usually decode the path segments before passing to user code. This commit does the same in our router