### PR TITLE
refactor: remove 'Pure' from schema definitions

### DIFF
--- a/pkg/kernel/src/schema.ml
+++ b/pkg/kernel/src/schema.ml
@@ -53,7 +53,6 @@ type _ field =
   | Object : 'a t -> 'a field
 
 and _ t =
-  | Pure : 'a -> 'a t
   | Field :
       { field : 'a field
       ; name : string
@@ -111,7 +110,6 @@ let validate : type a b. (a -> (b, string list) result) -> a t -> b t =
 let map : type a b. (a -> b) -> a t -> b t =
  fun f -> validate (fun v -> Ok (f v))
 
-let return : type a. a -> a t = fun v -> Pure v
 let field name field = Field { field; name }
 
 let int ?default ?constraint_ name =
@@ -415,7 +413,6 @@ let rec eval_tree_internal : type a b.
     { eval = (fun tree input -> eval_tree_internal (module FI) tree input) }
   in
   match tree with
-  | Pure v -> Ok v
   | Field { field; name } ->
     (match FI.get_input name input with
     | Ok value -> FI.eval interp field value
@@ -441,7 +438,6 @@ let rec evaluate : type a b.
   =
  fun (type b) (module FI : FIELD_INTERPRETER with type input = b) tree input ->
   match tree with
-  | Pure v -> Ok v
   | Field { field; name } ->
     (match eval_tree_internal (module FI) (Field { field; name }) input with
     | Ok v -> Ok v

--- a/pkg/kernel/src/schema.mli
+++ b/pkg/kernel/src/schema.mli
@@ -129,7 +129,6 @@ type _ field =
   | Object : 'a t -> 'a field
 
 and _ t =
-  | Pure : 'a -> 'a t
   | Field :
       { field : 'a field
       ; name : string
@@ -209,7 +208,6 @@ end
 
 val validate : ('a -> ('b, string list) result) -> 'a t -> 'b t
 val map : ('a -> 'b) -> 'a t -> 'b t
-val return : 'a -> 'a t
 val field : string -> 'a field -> 'a t
 val int : ?default:int -> ?constraint_:int Constraint.t -> string -> int t
 

--- a/src/openapi.ml
+++ b/src/openapi.ml
@@ -254,7 +254,6 @@ let rec field_to_openapi_schema : type a. a Schema.field -> Yojson.Safe.t =
 and schema_to_openapi_schema : type a. a Schema.t -> Yojson.Safe.t =
  fun schema ->
   match schema with
-  | Pure _ -> `Assoc [ "type", `String "object" ]
   | Field { field; name } ->
     let field_schema = field_to_openapi_schema field in
     `Assoc
@@ -282,7 +281,6 @@ and schema_to_openapi_schema : type a. a Schema.t -> Yojson.Safe.t =
 let rec schema_to_query_parameters : type a. a Schema.t -> parameter list =
  fun schema ->
   match schema with
-  | Pure _ -> []
   | Field { field; name } ->
     let is_required, param_schema =
       match field with
@@ -324,7 +322,6 @@ let rec schema_to_query_parameters : type a. a Schema.t -> parameter list =
 let rec schema_to_header_parameters : type a. a Schema.t -> parameter list =
  fun schema ->
   match schema with
-  | Pure _ -> []
   | Field { field; name } ->
     let is_required, param_schema =
       match field with
@@ -366,7 +363,6 @@ let rec schema_to_header_parameters : type a. a Schema.t -> parameter list =
 let rec schema_to_cookie_parameters : type a. a Schema.t -> parameter list =
  fun schema ->
   match schema with
-  | Pure _ -> []
   | Field { field; name } ->
     let is_required, param_schema =
       match field with


### PR DESCRIPTION
'Pure' not needed in schema definitions, since we only support `Applicative` interface.