### PR TITLE
fix: add tests for Request.is_secure function

### DIFF
--- a/src/request.ml
+++ b/src/request.ml
@@ -58,7 +58,12 @@ let is_secure ?trusted_proxies t =
   else
     match trusted_proxies with
     | None -> false
-    | Some trusted_proxies -> is_trusted_proxy ~trusted_proxies t.client_addr
+    | Some trusted_proxies ->
+      is_trusted_proxy ~trusted_proxies t.client_addr
+      &&
+        (match header "X-Forwarded-Proto" t with
+        | Some proto -> String.lowercase_ascii proto = "https"
+        | None -> false)
 
 let make
       ?(version = `HTTP_1_1)

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,4 @@
 (test
  (name test)
  (package tapak)
- (libraries tapak jsont jsont.bytesrw alcotest eio_main fmt))
+ (libraries tapak jsont jsont.bytesrw alcotest eio_main fmt ipaddr))

--- a/test/test.ml
+++ b/test/test.ml
@@ -3,7 +3,8 @@ let () =
   Alcotest.run
     "Tapak Tests"
     (List.flatten
-       [ Test_form.tests
+       [ Test_request.tests
+       ; Test_form.tests
        ; Test_router.tests
        ; Test_static.tests
        ; Test_sse.tests

--- a/test/test_request.ml
+++ b/test/test_request.ml
@@ -1,0 +1,65 @@
+let trusted_proxies = [ Ipaddr.Prefix.of_string_exn "10.0.1.0/24" ]
+
+let test_is_secure_trusted_with_proto () =
+  let request =
+    Tapak.Request.make
+      ~client_addr:"10.0.1.8"
+      ~headers:(Http.Header.of_list [ "X-Forwarded-Proto", "https" ])
+      "/admin"
+  in
+  Alcotest.(check bool)
+    "trusted proxy with X-Forwarded-Proto: https should be secure"
+    true
+    (Tapak.Request.is_secure ~trusted_proxies request)
+
+let test_is_secure_trusted_without_proto () =
+  let request = Tapak.Request.make ~client_addr:"10.0.1.8" "/admin" in
+  Alcotest.(check bool)
+    "trusted proxy without X-Forwarded-Proto should not be secure"
+    false
+    (Tapak.Request.is_secure ~trusted_proxies request)
+
+let test_is_secure_trusted_http_proto () =
+  let request =
+    Tapak.Request.make
+      ~client_addr:"10.0.1.8"
+      ~headers:(Http.Header.of_list [ "X-Forwarded-Proto", "http" ])
+      "/admin"
+  in
+  Alcotest.(check bool)
+    "trusted proxy with X-Forwarded-Proto: http should not be secure"
+    false
+    (Tapak.Request.is_secure ~trusted_proxies request)
+
+let test_is_secure_untrusted_proxy () =
+  let request =
+    Tapak.Request.make
+      ~client_addr:"192.168.1.1"
+      ~headers:(Http.Header.of_list [ "X-Forwarded-Proto", "https" ])
+      "/admin"
+  in
+  Alcotest.(check bool)
+    "untrusted proxy with X-Forwarded-Proto: https should not be secure"
+    false
+    (Tapak.Request.is_secure ~trusted_proxies request)
+
+let tests =
+  [ ( "Request"
+    , [ Alcotest.test_case
+          "is_secure: trusted proxy with https proto"
+          `Quick
+          test_is_secure_trusted_with_proto
+      ; Alcotest.test_case
+          "is_secure: trusted proxy without proto header"
+          `Quick
+          test_is_secure_trusted_without_proto
+      ; Alcotest.test_case
+          "is_secure: trusted proxy with http proto"
+          `Quick
+          test_is_secure_trusted_http_proto
+      ; Alcotest.test_case
+          "is_secure: untrusted proxy with https proto"
+          `Quick
+          test_is_secure_untrusted_proxy
+      ] )
+  ]


### PR DESCRIPTION
also fix a bug in the implementation of Request.is_secure where it was not correctly checking for the "X-Forwarded-Proto" header when determining if a request is secure.