### PR TITLE
feat: allow to specify conn closed callback in server

### DIFF
--- a/src/server.ml
+++ b/src/server.ml
@@ -122,11 +122,19 @@ let make :
   in
   Cohttp_eio.Server.make_response_action ?conn_closed ~callback ()
 
-let run ?max_connections ?additional_domains ?stop ~on_error socket service =
+let run
+      ?conn_closed
+      ?max_connections
+      ?additional_domains
+      ?stop
+      ~on_error
+      socket
+      service
+  =
   Cohttp_eio.Server.run
     ?max_connections
     ?additional_domains
     ?stop
     ~on_error
     socket
-    (make service)
+    (make ?conn_closed service)

--- a/src/server.mli
+++ b/src/server.mli
@@ -4,7 +4,8 @@ val make :
   -> Cohttp_eio.Server.t
 
 val run :
-   ?max_connections:int
+   ?conn_closed:(Cohttp_eio.Server.conn -> unit)
+  -> ?max_connections:int
   -> ?additional_domains:_ Eio.Domain_manager.t * int
   -> ?stop:'a Eio.Promise.t
   -> on_error:(exn -> unit)

--- a/src/tapak.mli
+++ b/src/tapak.mli
@@ -131,7 +131,8 @@ val openapi :
   -> string
 
 val run :
-   ?max_connections:int
+   ?conn_closed:(Cohttp_eio.Server.conn -> unit)
+  -> ?max_connections:int
   -> ?additional_domains:_ Eio.Domain_manager.t * int
   -> ?stop:'a Eio.Promise.t
   -> on_error:(exn -> unit)


### PR DESCRIPTION
this use cohttp's on_connection_closed callback to allow user to specify a callback when connection is closed.